### PR TITLE
Fix GitHub bot compilation and errors

### DIFF
--- a/src/features/network-diagram/hooks/useNetworkEditor.ts
+++ b/src/features/network-diagram/hooks/useNetworkEditor.ts
@@ -32,6 +32,7 @@ import {
   ComputerHost,
 } from '../lib/network-simulator/nodes/server';
 import { SwitchHost } from '../lib/network-simulator/nodes/switch';
+import { SpanningTreeProtocol } from '../lib/network-simulator/services/spanningtree';
 import { RouterHost } from '../lib/network-simulator/nodes/router';
 import type { CableUIType } from '../lib/network-simulator/cables';
 import { useNetworkLinks, type EdgeInterfaceStates } from './useNetworkLinks';
@@ -81,10 +82,10 @@ function createSimulatorNode(device: Device): GenericNode {
       simNode = new RouterHost(name, 2); // Router with 2 interfaces
       break;
     case 'switch':
-      simNode = new SwitchHost(name, 24, true); // Switch with 24 ports, STP enabled
+      simNode = new SwitchHost(name, 24); // Switch with 24 ports, default RPVST
       break;
     case 'hub':
-      simNode = new SwitchHost(name, 8, false); // Hub is a switch with 8 ports
+      simNode = new SwitchHost(name, 8, SpanningTreeProtocol.None); // Hub is a switch with 8 ports, STP disabled
       break;
     case 'server':
       simNode = new ServerHost(name, type, 1); // Server with 1 interface
@@ -236,8 +237,10 @@ export function useNetworkEditor(
 
           // Detect actual cable type based on device types
           const actualCableType = detectCableType(
-            (iface1.Host as unknown as SimNode).type as DeviceType,
-            (iface2.Host as unknown as SimNode).type as DeviceType
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (iface1.Host as unknown as SimNode<any>).type as DeviceType,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (iface2.Host as unknown as SimNode<any>).type as DeviceType
           );
 
           const edge = {

--- a/src/features/network-diagram/hooks/useNetworkLinks.ts
+++ b/src/features/network-diagram/hooks/useNetworkLinks.ts
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { InterfaceState } from '../components/edges/CustomEdge';
 import type { DeviceType, Network } from '../lib/network-simulator';
 import { Link, Node as SimNode } from '../lib/network-simulator';
-import type { CableUIType } from '../lib/network-simulator/cables';
+import type { CableUIType, CableType } from '../lib/network-simulator/cables';
 import {
   detectCableType,
   getCableVisualProps,
@@ -32,7 +32,7 @@ interface CreateLinkResult {
   linkId?: string;
   sourcePort?: string;
   targetPort?: string;
-  cableType?: CableUIType;
+  cableType?: CableType;
 }
 
 interface UseNetworkLinksReturn {

--- a/src/features/network-diagram/hooks/useStpService.ts
+++ b/src/features/network-diagram/hooks/useStpService.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { SwitchHost } from '../lib/network-simulator/nodes/switch';
+import { SwitchHost } from '../lib/network-simulator/nodes/switch';
 import type { Network } from '../lib/network-simulator/network';
 import {
   SpanningTreeState,
@@ -58,6 +58,9 @@ export default function useStpService(
         return;
       }
 
+      // Assign to const for type narrowing in nested function
+      const currentNetwork = network;
+
       // Find all connected switches in the same broadcast domain using graph traversal
       const visited = new Set<string>();
       const connectedSwitches: SwitchHost[] = [];
@@ -68,7 +71,7 @@ export default function useStpService(
         connectedSwitches.push(currentSwitch);
 
         // Find all links connected to this switch
-        network.links.forEach((link) => {
+        currentNetwork.links.forEach((link) => {
           const iface1 = link.getInterface(0);
           const iface2 = link.getInterface(1);
 

--- a/src/features/network-diagram/lib/network-simulator/address.ts
+++ b/src/features/network-diagram/lib/network-simulator/address.ts
@@ -175,6 +175,16 @@ export class IPAddress extends NetworkAddress {
     return 0;
   }
 
+  public toNumber(): number {
+    const parts = this.address.split('.');
+    return (
+      (parseInt(parts[0], 10) << 24) +
+      (parseInt(parts[1], 10) << 16) +
+      (parseInt(parts[2], 10) << 8) +
+      parseInt(parts[3], 10)
+    );
+  }
+
   public static generateAddress(): IPAddress {
     const ip = new Array(4);
     for (let i = 0; i < 4; i += 1) ip[i] = Math.floor(Math.random() * 256);

--- a/src/features/network-diagram/lib/network-simulator/examples/arp-discovery.ts
+++ b/src/features/network-diagram/lib/network-simulator/examples/arp-discovery.ts
@@ -19,7 +19,7 @@ export default function createARPDiscoveryExample(): Network {
   const network = new Network();
 
   // Create Switch
-  const switchDevice = new SwitchHost('Switch-1', 4, true);
+  const switchDevice = new SwitchHost('Switch-1', 4);
   switchDevice.guid = 'switch-arp-example';
   switchDevice.x = 300;
   switchDevice.y = 200;

--- a/src/features/network-diagram/lib/network-simulator/examples/autonegotiation.ts
+++ b/src/features/network-diagram/lib/network-simulator/examples/autonegotiation.ts
@@ -58,7 +58,7 @@ export default function createAutoNegotiationDemo(): Network {
   pc.getInterface(0).setMacAddress(new MacAddress('AA:BB:CC:DD:EE:10'));
 
   // Create Switch with Gigabit capability (10-1000 Mbps) - default
-  const switchDevice = new SwitchHost('Switch-GigEth', 2, true);
+  const switchDevice = new SwitchHost('Switch-GigEth', 2);
   switchDevice.guid = 'switch-autoneg-demo';
   switchDevice.x = 400;
   switchDevice.y = 200;

--- a/src/features/network-diagram/lib/network-simulator/examples/dhcp-setup.ts
+++ b/src/features/network-diagram/lib/network-simulator/examples/dhcp-setup.ts
@@ -38,7 +38,7 @@ export default function createDHCPSetupExample(): Network {
   server.services.dhcp.Enable = true;
 
   // Create Switch
-  const switchDevice = new SwitchHost('Switch-1', 4, true);
+  const switchDevice = new SwitchHost('Switch-1', 4);
   switchDevice.guid = 'switch-example';
   switchDevice.x = 300;
   switchDevice.y = 200;

--- a/src/features/network-diagram/lib/network-simulator/examples/vlan-trunk.ts
+++ b/src/features/network-diagram/lib/network-simulator/examples/vlan-trunk.ts
@@ -21,7 +21,7 @@ export default function createVLANTrunkExample(): Network {
   const network = new Network();
 
   // Create two switches
-  const switch1 = new SwitchHost('Switch-1', 3, true);
+  const switch1 = new SwitchHost('Switch-1', 3);
   switch1.guid = 'switch1-vlan-example';
   switch1.x = 200;
   switch1.y = 200;
@@ -29,7 +29,7 @@ export default function createVLANTrunkExample(): Network {
   switch1.getInterface(1).up(); // PC-B (VLAN 20)
   switch1.getInterface(2).up(); // Trunk to Switch-2
 
-  const switch2 = new SwitchHost('Switch-2', 3, true);
+  const switch2 = new SwitchHost('Switch-2', 3);
   switch2.guid = 'switch2-vlan-example';
   switch2.x = 500;
   switch2.y = 200;

--- a/src/features/network-diagram/lib/network-simulator/layers/datalink.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/layers/datalink.test.ts
@@ -7,6 +7,7 @@ import { Link } from './physical';
 import { MacAddress } from '../address';
 import { AutonegotiationMessage } from '../protocols/autonegotiation';
 import { SwitchHost } from '../nodes/switch';
+import { SpanningTreeProtocol } from '../services/spanningtree';
 import { PhysicalMessage, type DatalinkMessage } from '../message';
 import { HardwareInterface, EthernetInterface } from './datalink';
 import { VlanMode } from '../protocols/ethernet';
@@ -62,17 +63,18 @@ describe('Datalink layer test', () => {
   beforeEach(() => {
     Scheduler.getInstance().Speed = SchedulerState.FASTER;
 
-    A = new SwitchHost('A', 1);
+    // Disable STP in test switches to prevent RSTP message interference
+    A = new SwitchHost('A', 1, SpanningTreeProtocol.None);
     A.getInterfaces().forEach((i) => {
       A.getInterface(i).up();
     });
 
-    B = new SwitchHost('B', 2);
+    B = new SwitchHost('B', 2, SpanningTreeProtocol.None);
     B.getInterfaces().forEach((i) => {
       B.getInterface(i).up();
     });
 
-    C = new SwitchHost('C', 1);
+    C = new SwitchHost('C', 1, SpanningTreeProtocol.None);
     C.getInterfaces().forEach((i) => {
       C.getInterface(i).up();
     });

--- a/src/features/network-diagram/lib/network-simulator/layers/network.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/layers/network.test.ts
@@ -7,6 +7,7 @@ import { Link, type Interface } from './physical';
 import { IPAddress, MacAddress } from '../address';
 import { RouterHost } from '../nodes/router';
 import { SwitchHost } from '../nodes/switch';
+import { SpanningTreeProtocol } from '../services/spanningtree';
 import type { NetworkMessage } from '../message';
 import { ActionHandle, type NetworkListener } from '../protocols/base';
 
@@ -61,7 +62,8 @@ describe('Network layer test', () => {
     A.name = 'A';
     A.addInterface().up();
 
-    B = new SwitchHost();
+    // Disable STP in test switch to prevent RSTP message interference
+    B = new SwitchHost('', 0, SpanningTreeProtocol.None);
     B.name = 'B';
     B.addInterface().up();
     B.addInterface().up();

--- a/src/features/network-diagram/lib/network-simulator/network.ts
+++ b/src/features/network-diagram/lib/network-simulator/network.ts
@@ -3,6 +3,7 @@ import { GenericNode, NetworkHost } from './nodes/generic';
 import { RouterHost } from './nodes/router';
 import { ComputerHost, ServerHost } from './nodes/server';
 import { SwitchHost } from './nodes/switch';
+import { SpanningTreeProtocol } from './services/spanningtree';
 
 /**
  * Network topology representation
@@ -121,9 +122,9 @@ export class Network {
       } else if (type === 'router') {
         node = new RouterHost();
       } else if (type === 'switch') {
-        node = new SwitchHost('', 0, true);
+        node = new SwitchHost('', 0);
       } else if (type === 'hub') {
-        node = new SwitchHost('', 0, false);
+        node = new SwitchHost('', 0, SpanningTreeProtocol.None);
       } else {
         // eslint-disable-next-line no-console
         console.warn(`[Network] Skipping unknown device type: ${type}`);

--- a/src/features/network-diagram/lib/network-simulator/protocols/arp.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/arp.test.ts
@@ -4,6 +4,7 @@ import { Link } from '../layers/physical';
 import { ArpMessage } from './arp';
 import { RouterHost } from '../nodes/router';
 import { SwitchHost } from '../nodes/switch';
+import { SpanningTreeProtocol } from '../services/spanningtree';
 import { ActionHandle, type DatalinkListener } from './base';
 import type { DatalinkMessage } from '../message';
 import {
@@ -70,7 +71,8 @@ describe('ARP Protocol test', () => {
     A.name = 'A';
     A.addInterface().up();
 
-    B = new SwitchHost();
+    // Disable STP in test switch to prevent RSTP message interference
+    B = new SwitchHost('', 0, SpanningTreeProtocol.None);
     B.name = 'B';
     B.addInterface().up();
     B.addInterface().up();

--- a/src/features/network-diagram/lib/network-simulator/protocols/checksum.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/checksum.test.ts
@@ -105,7 +105,8 @@ describe('CRC-32 (IEEE 802.3)', () => {
 
     it('should handle empty data', () => {
       const crc = crc32([]);
-      expect(crc).toBe(0xffffffff); // Initial value XOR 0xFFFFFFFF
+      // Empty data: initial (0xFFFFFFFF) XOR final (0xFFFFFFFF) = 0x00000000
+      expect(crc).toBe(0x00000000);
     });
 
     it('should handle single byte', () => {

--- a/src/features/network-diagram/lib/network-simulator/protocols/checksum.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/checksum.ts
@@ -9,6 +9,9 @@
  * - Parity/LRC: Simple checksums for serial protocols (RS-232, UART)
  */
 
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-plusplus */
+
 // ============================================================================
 // INTERNET CHECKSUM (RFC 1071)
 // ============================================================================

--- a/src/features/network-diagram/lib/network-simulator/protocols/ethernet.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/ethernet.test.ts
@@ -8,6 +8,7 @@ import { Link } from '../layers/physical';
 import { DatalinkMessage } from '../message';
 import { Dot1QMessage, EthernetMessage, VlanMode } from './ethernet';
 import { SwitchHost } from '../nodes/switch';
+import { SpanningTreeProtocol } from '../services/spanningtree';
 import { RouterHost } from '../nodes/router';
 import { MacAddress } from '../address';
 import { ActionHandle, type DatalinkListener } from './base';
@@ -58,15 +59,16 @@ describe('Ethernet protocol', () => {
   beforeEach(() => {
     Scheduler.getInstance().Speed = SchedulerState.FASTER;
 
-    A = new SwitchHost('A', 2);
+    // Disable STP in test switches to prevent RSTP message interference
+    A = new SwitchHost('A', 2, SpanningTreeProtocol.None);
     A.getInterface(0).up();
     A.getInterface(1).up();
 
-    B = new SwitchHost('B', 2);
+    B = new SwitchHost('B', 2, SpanningTreeProtocol.None);
     B.getInterface(0).up();
     B.getInterface(1).up();
 
-    C = new SwitchHost('C', 2);
+    C = new SwitchHost('C', 2, SpanningTreeProtocol.None);
     C.getInterface(0).up();
     C.getInterface(1).up();
 

--- a/src/features/network-diagram/lib/network-simulator/protocols/ethernet.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/ethernet.ts
@@ -36,12 +36,18 @@ export class EthernetMessage extends DatalinkMessage {
 
     // Add destination MAC (6 bytes)
     if (this.macDst) {
-      const dstBytes = this.macDst.toString().split(':').map(b => parseInt(b, 16));
+      const dstBytes = this.macDst
+        .toString()
+        .split(':')
+        .map((b) => parseInt(b, 16));
       bytes.push(...dstBytes);
     }
 
     // Add source MAC (6 bytes)
-    const srcBytes = this.macSrc.toString().split(':').map(b => parseInt(b, 16));
+    const srcBytes = this.macSrc
+      .toString()
+      .split(':')
+      .map((b) => parseInt(b, 16));
     bytes.push(...srcBytes);
 
     // Add EtherType/Length field (2 bytes)
@@ -52,10 +58,14 @@ export class EthernetMessage extends DatalinkMessage {
 
     if (payloadName.includes('ARP')) {
       etherType = 0x0806; // ARP
-    } else if (payloadName.includes('IPv4') || payloadName.includes('ICMP') || payloadName.includes('DHCP')) {
+    } else if (
+      payloadName.includes('IPv4') ||
+      payloadName.includes('ICMP') ||
+      payloadName.includes('DHCP')
+    ) {
       etherType = 0x0800; // IPv4
     } else if (payloadName.includes('IPv6')) {
-      etherType = 0x86DD; // IPv6
+      etherType = 0x86dd; // IPv6
     } else if (this.payload.length < 1536) {
       // IEEE 802.3: If < 1536, it's a Length field, not EtherType
       etherType = this.payload.length;
@@ -66,7 +76,7 @@ export class EthernetMessage extends DatalinkMessage {
 
     // Add EtherType as big-endian (network byte order)
     bytes.push((etherType >> 8) & 0xff); // High byte
-    bytes.push(etherType & 0xff);        // Low byte
+    bytes.push(etherType & 0xff); // Low byte
 
     // Add payload
     const payloadStr = this.payload.toString();

--- a/src/features/network-diagram/lib/network-simulator/protocols/ethernet.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/ethernet.ts
@@ -80,6 +80,7 @@ export class EthernetMessage extends DatalinkMessage {
 
     // Add payload
     const payloadStr = this.payload.toString();
+    // eslint-disable-next-line no-plusplus
     for (let i = 0; i < payloadStr.length; i++) {
       bytes.push(payloadStr.charCodeAt(i) & 0xff);
     }

--- a/src/features/network-diagram/lib/network-simulator/protocols/icmp.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/icmp.ts
@@ -63,13 +63,14 @@ export class ICMPMessage extends IPv4Message {
 
     // RFC 792: Rest of header (4 bytes - for Echo: Identifier + Sequence)
     words.push(this.identifier & 0xffff); // Identifier (16 bits)
-    words.push(this.sequence & 0xffff);   // Sequence (16 bits)
+    words.push(this.sequence & 0xffff); // Sequence (16 bits)
 
     // Add payload data as 16-bit words
     const payloadStr = this.payload.toString();
     for (let i = 0; i < payloadStr.length; i += 2) {
       const highByte = payloadStr.charCodeAt(i);
-      const lowByte = i + 1 < payloadStr.length ? payloadStr.charCodeAt(i + 1) : 0;
+      const lowByte =
+        i + 1 < payloadStr.length ? payloadStr.charCodeAt(i + 1) : 0;
       words.push(((highByte << 8) | lowByte) & 0xffff);
     }
 
@@ -212,8 +213,8 @@ export class ICMPProtocol implements NetworkListener {
           .setNetSource(message.netDst as IPAddress)
           .setNetDestination(message.netSrc as IPAddress)
           .setIdentification(message.identification)
-          .setIdentifier(message.identifier)  // Copy from request
-          .setSequence(message.sequence)      // Copy from request
+          .setIdentifier(message.identifier) // Copy from request
+          .setSequence(message.sequence) // Copy from request
           .build()[0];
 
         this.iface.sendPacket(reply);

--- a/src/features/network-diagram/lib/network-simulator/protocols/ipv4.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/ipv4.ts
@@ -54,7 +54,9 @@ export class IPv4Message extends NetworkMessage {
     const words: number[] = [];
 
     // Version (4 bits) + IHL (4 bits) + TOS (8 bits)
-    words.push(((this.version << 12) | (this.headerLength << 8) | this.TOS) & 0xffff);
+    words.push(
+      ((this.version << 12) | (this.headerLength << 8) | this.TOS) & 0xffff
+    );
 
     // Total Length (16 bits)
     words.push(this.totalLength & 0xffff);
@@ -180,9 +182,10 @@ export class IPv4Message extends NetworkMessage {
       if (this.ttl > 255) throw new Error('TTL must be <= 255');
 
       // Convert payload to string for fragmentation
-      const payloadStr = typeof this.payload === 'string'
-        ? this.payload
-        : this.payload.toString();
+      const payloadStr =
+        typeof this.payload === 'string'
+          ? this.payload
+          : this.payload.toString();
       const payloadLength = payloadStr.length;
 
       // RFC 791: Header size (minimum 20 bytes for no options)
@@ -190,7 +193,8 @@ export class IPv4Message extends NetworkMessage {
 
       // RFC 791: Calculate maximum payload per fragment
       // Fragment data must be multiple of 8 bytes (except last fragment)
-      const maxDataPerFragment = Math.floor((this.maxSize - headerBytes) / 8) * 8;
+      const maxDataPerFragment =
+        Math.floor((this.maxSize - headerBytes) / 8) * 8;
 
       // If no fragmentation needed, return single packet
       if (headerBytes + payloadLength <= this.maxSize) {
@@ -230,7 +234,11 @@ export class IPv4Message extends NetworkMessage {
         );
 
         // Create fragment message
-        const message = new IPv4Message(fragmentPayload, this.netSrc, this.netDst);
+        const message = new IPv4Message(
+          fragmentPayload,
+          this.netSrc,
+          this.netDst
+        );
         message.ttl = this.ttl;
         message.identification = this.id;
         message.protocol = this.protocol;

--- a/src/features/network-diagram/lib/network-simulator/services/dhcp.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/services/dhcp.test.ts
@@ -15,6 +15,7 @@ import {
 import { ServerHost } from '../nodes/server';
 import { RouterHost } from '../nodes/router';
 import { SwitchHost } from '../nodes/switch';
+import { SpanningTreeProtocol } from './spanningtree';
 
 describe('DHCP protocol', () => {
   let A: ServerHost;
@@ -38,7 +39,8 @@ describe('DHCP protocol', () => {
     C.name = 'C';
     C.addInterface().up();
 
-    S = new SwitchHost();
+    // Disable STP in test switch to prevent RSTP message interference
+    S = new SwitchHost('', 0, SpanningTreeProtocol.None);
     S.addInterface().up();
     S.addInterface().up();
     S.addInterface().up();

--- a/src/features/network-diagram/lib/network-simulator/services/spanningtree.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/services/spanningtree.test.ts
@@ -54,16 +54,42 @@ async function waitForConvergence(
 }
 
 describe('SpanningTreeService - RFC 802.1D Compliance', () => {
+  // Track all created switches for cleanup
+  const createdSwitches = new Set<SwitchHost>();
+
+  // Helper to create and track switches for automatic cleanup
+  const createSwitch = (
+    name: string,
+    ports: number,
+    protocol?: SpanningTreeProtocol
+  ): SwitchHost => {
+    const sw = new SwitchHost(name, ports, protocol);
+    createdSwitches.add(sw);
+    return sw;
+  };
+
   // Set Scheduler to FASTER mode for all STP tests to avoid timeouts
   beforeEach(() => {
     Scheduler.getInstance().Speed = SchedulerState.FASTER;
+  });
+
+  // Global cleanup to prevent memory leaks
+  afterEach(() => {
+    createdSwitches.forEach((sw) => {
+      try {
+        sw.destroy();
+      } catch (_e) {
+        // Ignore errors during cleanup
+      }
+    });
+    createdSwitches.clear();
   });
 
   describe('MAC Address and Bridge ID', () => {
     let A: SwitchHost;
 
     beforeEach(() => {
-      A = new SwitchHost('A', 3, SpanningTreeProtocol.STP);
+      A = createSwitch('A', 3, SpanningTreeProtocol.STP);
       A.spanningTree.Enable = true;
     });
 
@@ -139,7 +165,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should elect switch with lowest Bridge ID as root', async () => {
-      const B = new SwitchHost('B', 1, SpanningTreeProtocol.STP);
+      const B = createSwitch('B', 1, SpanningTreeProtocol.STP);
       B.spanningTree.Enable = true;
 
       // Set A's MAC to be lower than B's
@@ -224,8 +250,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should advertise correct root in BPDU', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -267,8 +293,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('Root Bridge Election', () => {
     it('should elect root in simple 2-switch topology', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -298,11 +324,11 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should elect root in complex 5-switch topology', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
-      const D = new SwitchHost('D', 2);
-      const E = new SwitchHost('E', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
+      const D = createSwitch('D', 2);
+      const E = createSwitch('E', 2);
 
       // Set MAC addresses - A has the lowest
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
@@ -356,8 +382,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should handle equal priority with different MACs', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
@@ -388,9 +414,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should have all switches agree on same root', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -428,9 +454,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should re-elect root when current root fails', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -485,10 +511,10 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('Port Role Assignment', () => {
     it('should assign all ports as Designated on root bridge', async () => {
-      const A = new SwitchHost('A', 3);
-      const B = new SwitchHost('B', 1);
-      const C = new SwitchHost('C', 1);
-      const D = new SwitchHost('D', 1);
+      const A = createSwitch('A', 3);
+      const B = createSwitch('B', 1);
+      const C = createSwitch('C', 1);
+      const D = createSwitch('D', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -526,9 +552,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should have exactly one Root port on non-root bridge', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -570,9 +596,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should block redundant paths in triangle topology', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -643,9 +669,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should prevent both sides of cable being Blocked', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -715,9 +741,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
   describe('Root Port Tie-Breaking', () => {
     it('should select root port based on lowest cost', async () => {
       // Use STP (not RPVST) for faster convergence in this specific test
-      const A = new SwitchHost('A', 2, SpanningTreeProtocol.STP);
-      const B = new SwitchHost('B', 2, SpanningTreeProtocol.STP);
-      const C = new SwitchHost('C', 2, SpanningTreeProtocol.STP);
+      const A = createSwitch('A', 2, SpanningTreeProtocol.STP);
+      const B = createSwitch('B', 2, SpanningTreeProtocol.STP);
+      const C = createSwitch('C', 2, SpanningTreeProtocol.STP);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -784,7 +810,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('Port Cost Calculation', () => {
     it('should use hash-based port ID (not Number that gives NaN)', () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
 
       // Interface name like "GigabitEthernet0/0" would give NaN with Number()
@@ -806,9 +832,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should advertise root path cost, not interface cost', async () => {
-      const A = new SwitchHost('A', 1, SpanningTreeProtocol.STP);
-      const B = new SwitchHost('B', 2, SpanningTreeProtocol.STP);
-      const C = new SwitchHost('C', 1, SpanningTreeProtocol.STP);
+      const A = createSwitch('A', 1, SpanningTreeProtocol.STP);
+      const B = createSwitch('B', 2, SpanningTreeProtocol.STP);
+      const C = createSwitch('C', 1, SpanningTreeProtocol.STP);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -866,8 +892,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should only clear cost table when root actually changes', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -908,9 +934,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should calculate root port cost correctly', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -975,8 +1001,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('BPDU Aging and Timeout', () => {
     it('should reset BPDU timer on each new BPDU', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1010,8 +1036,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should detect BPDU timeout after maxAge', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1050,9 +1076,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should promote Blocked port to Designated after BPDU timeout', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1153,7 +1179,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('Port State Transitions', () => {
     it('should transition Disabled to Listening on interface up', () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
 
       const iface = A.getInterface(0);
@@ -1176,9 +1202,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should keep Blocked port in Blocking state', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1231,7 +1257,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should sync state with role change', () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
 
       const iface = A.getInterface(0);
@@ -1256,7 +1282,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('Edge Cases', () => {
     it('should discard own BPDU (loopback detection)', async () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
       A.getInterface(0).up();
 
@@ -1274,8 +1300,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should discard BPDU with messageAge >= maxAge', () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.spanningTree.Enable = true;
       B.spanningTree.Enable = true;
@@ -1309,7 +1335,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     it('should handle switch with no interfaces gracefully', () => {
       expect(() => {
-        const A = new SwitchHost('A', 0);
+        const A = createSwitch('A', 0);
         A.spanningTree.Enable = true;
         A.spanningTree.negociate();
         A.destroy();
@@ -1317,8 +1343,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should handle interface addition during convergence', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1358,7 +1384,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should handle rapid interface up/down events', async () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
 
       const iface = A.getInterface(0);
@@ -1383,9 +1409,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('Frame Forwarding Integration', () => {
     it('should drop incoming frames on Blocked port', async () => {
-      const A = new SwitchHost('A', 2);
-      const B = new SwitchHost('B', 2);
-      const C = new SwitchHost('C', 2);
+      const A = createSwitch('A', 2);
+      const B = createSwitch('B', 2);
+      const C = createSwitch('C', 2);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1446,7 +1472,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should learn MAC but not forward on Listening port', () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
 
       const iface = A.getInterface(0);
@@ -1464,7 +1490,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should learn MAC but not forward on Learning port', () => {
-      const A = new SwitchHost('A', 1);
+      const A = createSwitch('A', 1);
       A.spanningTree.Enable = true;
 
       const iface = A.getInterface(0);
@@ -1481,8 +1507,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should forward frames on Forwarding port', async () => {
-      const A = new SwitchHost('A', 1);
-      const B = new SwitchHost('B', 1);
+      const A = createSwitch('A', 1);
+      const B = createSwitch('B', 1);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1531,7 +1557,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
       // Create 5 switches
       for (let i = 0; i < 5; i += 1) {
-        const sw = new SwitchHost(`SW${i}`, 4);
+        const sw = createSwitch(`SW${i}`, 4);
         sw.getInterface(0).setMacAddress(
           new MacAddress(`00:00:00:00:00:0${i + 1}`)
         );
@@ -1569,9 +1595,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should handle multiple topology changes without memory leaks', async () => {
-      const A = new SwitchHost('A', 3);
-      const B = new SwitchHost('B', 3);
-      const C = new SwitchHost('C', 3);
+      const A = createSwitch('A', 3);
+      const B = createSwitch('B', 3);
+      const C = createSwitch('C', 3);
 
       A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
       B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
@@ -1618,7 +1644,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should cancel all timers on destroy()', () => {
-      const A = new SwitchHost('A', 2);
+      const A = createSwitch('A', 2);
       A.spanningTree.Enable = true;
       A.getInterface(0).up();
       A.getInterface(1).up();
@@ -1633,7 +1659,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
   describe('PVST (Per-VLAN Spanning Tree)', () => {
     it('should create PVSTService when protocol is PVST', () => {
-      const A = new SwitchHost('A', 2, SpanningTreeProtocol.PVST);
+      const A = createSwitch('A', 2, SpanningTreeProtocol.PVST);
       expect(A.getStpProtocol()).toBe(SpanningTreeProtocol.PVST);
       expect(A.spanningTree.getProtocolType()).toBe(SpanningTreeProtocol.PVST);
       A.destroy();
@@ -1641,8 +1667,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     it('should maintain independent STP states per VLAN', () => {
       // Create switches with PVST
-      const A = new SwitchHost('A', 2, SpanningTreeProtocol.PVST);
-      const B = new SwitchHost('B', 2, SpanningTreeProtocol.PVST);
+      const A = createSwitch('A', 2, SpanningTreeProtocol.PVST);
+      const B = createSwitch('B', 2, SpanningTreeProtocol.PVST);
 
       // Configure VLANs 10 and 20
       A.knownVlan[10] = 'VLAN 10';
@@ -1685,7 +1711,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should support protocol switching between STP and PVST', () => {
-      const A = new SwitchHost('A', 2, SpanningTreeProtocol.STP);
+      const A = createSwitch('A', 2, SpanningTreeProtocol.STP);
       expect(A.getStpProtocol()).toBe(SpanningTreeProtocol.STP);
 
       // Switch to PVST
@@ -1702,7 +1728,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should discover VLANs from knownVlan registry', () => {
-      const A = new SwitchHost('A', 2, SpanningTreeProtocol.PVST);
+      const A = createSwitch('A', 2, SpanningTreeProtocol.PVST);
 
       // Register VLANs
       A.knownVlan[10] = 'Engineering';
@@ -1729,7 +1755,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
   describe('RSTP (Rapid Spanning Tree) - IEEE 802.1w', () => {
     describe('Basic RSTP Functionality', () => {
       it('should create RSTPService when protocol is RSTP', () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RSTP);
         expect(A.getStpProtocol()).toBe(SpanningTreeProtocol.RSTP);
         expect(A.spanningTree.getProtocolType()).toBe(
           SpanningTreeProtocol.RSTP
@@ -1738,8 +1764,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       }, 15000); // 15s timeout for RSTP tests
 
       it('should send version 2 BPDUs', async () => {
-        const A = new SwitchHost('A', 1, SpanningTreeProtocol.RSTP);
-        const B = new SwitchHost('B', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 1, SpanningTreeProtocol.RSTP);
+        const B = createSwitch('B', 1, SpanningTreeProtocol.RSTP);
 
         A.spanningTree.Enable = true;
         B.spanningTree.Enable = true;
@@ -1775,8 +1801,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       });
 
       it('should encode port role in BPDU flags', async () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RSTP);
-        const B = new SwitchHost('B', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RSTP);
+        const B = createSwitch('B', 1, SpanningTreeProtocol.RSTP);
 
         A.spanningTree.Enable = true;
         B.spanningTree.Enable = true;
@@ -1816,7 +1842,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     describe('Edge Port Auto-Detection', () => {
       it('should mark port as edge after 3 seconds without BPDU', async () => {
-        const A = new SwitchHost('A', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 1, SpanningTreeProtocol.RSTP);
         A.spanningTree.Enable = true;
 
         // Initially not edge
@@ -1838,8 +1864,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       });
 
       it('should disable edge status when BPDU is received', async () => {
-        const A = new SwitchHost('A', 1, SpanningTreeProtocol.RSTP);
-        const B = new SwitchHost('B', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 1, SpanningTreeProtocol.RSTP);
+        const B = createSwitch('B', 1, SpanningTreeProtocol.RSTP);
 
         A.spanningTree.Enable = true;
         B.spanningTree.Enable = true;
@@ -1886,8 +1912,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     describe('Proposal/Agreement Mechanism', () => {
       it('should send proposal on designated port', async () => {
-        const A = new SwitchHost('A', 1, SpanningTreeProtocol.RSTP);
-        const B = new SwitchHost('B', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 1, SpanningTreeProtocol.RSTP);
+        const B = createSwitch('B', 1, SpanningTreeProtocol.RSTP);
 
         A.spanningTree.Enable = true;
         B.spanningTree.Enable = true;
@@ -1925,8 +1951,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       });
 
       it('should respond with agreement when receiving proposal', async () => {
-        const A = new SwitchHost('A', 1, SpanningTreeProtocol.RSTP);
-        const B = new SwitchHost('B', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 1, SpanningTreeProtocol.RSTP);
+        const B = createSwitch('B', 1, SpanningTreeProtocol.RSTP);
 
         A.spanningTree.Enable = true;
         B.spanningTree.Enable = true;
@@ -1967,9 +1993,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     describe('Rapid Convergence', () => {
       it('should converge faster than STP in triangle topology', async () => {
         // Create RSTP triangle
-        const aRstp = new SwitchHost('A_RSTP', 2, SpanningTreeProtocol.RSTP);
-        const bRstp = new SwitchHost('B_RSTP', 2, SpanningTreeProtocol.RSTP);
-        const cRstp = new SwitchHost('C_RSTP', 2, SpanningTreeProtocol.RSTP);
+        const aRstp = createSwitch('A_RSTP', 2, SpanningTreeProtocol.RSTP);
+        const bRstp = createSwitch('B_RSTP', 2, SpanningTreeProtocol.RSTP);
+        const cRstp = createSwitch('C_RSTP', 2, SpanningTreeProtocol.RSTP);
 
         aRstp.spanningTree.Enable = true;
         bRstp.spanningTree.Enable = true;
@@ -2005,8 +2031,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       }, 10000); // 10s timeout
 
       it('should use rapid state transitions with proposal/agreement', async () => {
-        const A = new SwitchHost('A', 1, SpanningTreeProtocol.RSTP);
-        const B = new SwitchHost('B', 1, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 1, SpanningTreeProtocol.RSTP);
+        const B = createSwitch('B', 1, SpanningTreeProtocol.RSTP);
 
         A.spanningTree.Enable = true;
         B.spanningTree.Enable = true;
@@ -2041,8 +2067,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     describe('STP/RSTP Interoperability', () => {
       it('should detect STP neighbor and fall back', async () => {
-        const aRstp = new SwitchHost('A_RSTP', 1, SpanningTreeProtocol.RSTP);
-        const bStp = new SwitchHost('B_STP', 1, SpanningTreeProtocol.STP);
+        const aRstp = createSwitch('A_RSTP', 1, SpanningTreeProtocol.RSTP);
+        const bStp = createSwitch('B_STP', 1, SpanningTreeProtocol.STP);
 
         aRstp.spanningTree.Enable = true;
         bStp.spanningTree.Enable = true;
@@ -2077,8 +2103,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       });
 
       it('should not send proposals to STP neighbors', () => {
-        const aRstp = new SwitchHost('A_RSTP', 1, SpanningTreeProtocol.RSTP);
-        const bStp = new SwitchHost('B_STP', 1, SpanningTreeProtocol.STP);
+        const aRstp = createSwitch('A_RSTP', 1, SpanningTreeProtocol.RSTP);
+        const bStp = createSwitch('B_STP', 1, SpanningTreeProtocol.STP);
 
         aRstp.spanningTree.Enable = true;
         bStp.spanningTree.Enable = true;
@@ -2123,7 +2149,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
   describe('R-PVST (Rapid Per-VLAN Spanning Tree)', () => {
     describe('Basic R-PVST Functionality', () => {
       it('should create RPVSTService when protocol is RPVST', () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RPVST);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RPVST);
         expect(A.getStpProtocol()).toBe(SpanningTreeProtocol.RPVST);
         expect(A.spanningTree.getProtocolType()).toBe(
           SpanningTreeProtocol.RPVST
@@ -2132,8 +2158,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       });
 
       it('should maintain independent RSTP states per VLAN', () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RPVST);
-        const B = new SwitchHost('B', 2, SpanningTreeProtocol.RPVST);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RPVST);
+        const B = createSwitch('B', 2, SpanningTreeProtocol.RPVST);
 
         // Configure VLANs 10 and 20
         A.knownVlan[10] = 'VLAN 10';
@@ -2176,7 +2202,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       });
 
       it('should support protocol switching to RPVST', () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RSTP);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RSTP);
         expect(A.getStpProtocol()).toBe(SpanningTreeProtocol.RSTP);
 
         // Switch to R-PVST
@@ -2192,8 +2218,8 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     describe('Per-VLAN Rapid Convergence', () => {
       it('should converge rapidly per VLAN (< 5s)', async () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RPVST);
-        const B = new SwitchHost('B', 2, SpanningTreeProtocol.RPVST);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RPVST);
+        const B = createSwitch('B', 2, SpanningTreeProtocol.RPVST);
 
         // Configure VLANs 10 and 20
         A.knownVlan[10] = 'VLAN 10';
@@ -2233,9 +2259,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       }, 10000);
 
       it('should have independent convergence per VLAN', async () => {
-        const A = new SwitchHost('A', 3, SpanningTreeProtocol.RPVST);
-        const B = new SwitchHost('B', 3, SpanningTreeProtocol.RPVST);
-        const C = new SwitchHost('C', 3, SpanningTreeProtocol.RPVST);
+        const A = createSwitch('A', 3, SpanningTreeProtocol.RPVST);
+        const B = createSwitch('B', 3, SpanningTreeProtocol.RPVST);
+        const C = createSwitch('C', 3, SpanningTreeProtocol.RPVST);
 
         // VLAN 10: all switches participate
         A.knownVlan[10] = 'VLAN 10';
@@ -2289,7 +2315,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     describe('Per-VLAN Edge Port Detection', () => {
       it('should detect edge ports independently per VLAN', async () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RPVST);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RPVST);
 
         // Configure VLANs
         A.knownVlan[10] = 'VLAN 10';
@@ -2327,7 +2353,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
 
     describe('R-PVST Protocol Discovery', () => {
       it('should discover VLANs and create RSTP instances', () => {
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.RPVST);
+        const A = createSwitch('A', 2, SpanningTreeProtocol.RPVST);
 
         // Register multiple VLANs
         A.knownVlan[10] = 'Engineering';
@@ -2355,10 +2381,10 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
   describe('Protocol Propagation', () => {
     it('should propagate protocol change to all connected switches in broadcast domain', () => {
       // Create a network topology: A -- B -- C    D (isolated)
-      const A = new SwitchHost('A', 1, SpanningTreeProtocol.STP);
-      const B = new SwitchHost('B', 2, SpanningTreeProtocol.STP);
-      const C = new SwitchHost('C', 1, SpanningTreeProtocol.STP);
-      const D = new SwitchHost('D', 1, SpanningTreeProtocol.STP);
+      const A = createSwitch('A', 1, SpanningTreeProtocol.STP);
+      const B = createSwitch('B', 2, SpanningTreeProtocol.STP);
+      const C = createSwitch('C', 1, SpanningTreeProtocol.STP);
+      const D = createSwitch('D', 1, SpanningTreeProtocol.STP);
 
       A.getInterface(0).up();
       B.getInterface(0).up();
@@ -2451,10 +2477,10 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       // Create a star topology: B -- A -- C
       //                              |
       //                              D
-      const A = new SwitchHost('A', 3, SpanningTreeProtocol.PVST);
-      const B = new SwitchHost('B', 1, SpanningTreeProtocol.PVST);
-      const C = new SwitchHost('C', 1, SpanningTreeProtocol.PVST);
-      const D = new SwitchHost('D', 1, SpanningTreeProtocol.PVST);
+      const A = createSwitch('A', 3, SpanningTreeProtocol.PVST);
+      const B = createSwitch('B', 1, SpanningTreeProtocol.PVST);
+      const C = createSwitch('C', 1, SpanningTreeProtocol.PVST);
+      const D = createSwitch('D', 1, SpanningTreeProtocol.PVST);
 
       A.getInterface(0).up();
       A.getInterface(1).up();
@@ -2524,7 +2550,7 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
     });
 
     it('should handle single isolated switch', () => {
-      const A = new SwitchHost('A', 1, SpanningTreeProtocol.STP);
+      const A = createSwitch('A', 1, SpanningTreeProtocol.STP);
       A.getInterface(0).up();
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2578,9 +2604,9 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
       // Create topology: Switch A -- Switch B -- Router -- Switch C
       // A and B are in same broadcast domain
       // C is in different broadcast domain (separated by router)
-      const A = new SwitchHost('A', 1, SpanningTreeProtocol.STP);
-      const B = new SwitchHost('B', 2, SpanningTreeProtocol.STP);
-      const C = new SwitchHost('C', 1, SpanningTreeProtocol.STP);
+      const A = createSwitch('A', 1, SpanningTreeProtocol.STP);
+      const B = createSwitch('B', 2, SpanningTreeProtocol.STP);
+      const C = createSwitch('C', 1, SpanningTreeProtocol.STP);
       const Router = new RouterHost('Router', 2);
 
       A.getInterface(0).up();

--- a/src/features/network-diagram/lib/network-simulator/services/spanningtree.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/services/spanningtree.test.ts
@@ -713,73 +713,69 @@ describe('SpanningTreeService - RFC 802.1D Compliance', () => {
   });
 
   describe('Root Port Tie-Breaking', () => {
-    it(
-      'should select root port based on lowest cost',
-      async () => {
-        // Use STP (not RPVST) for faster convergence in this specific test
-        const A = new SwitchHost('A', 2, SpanningTreeProtocol.STP);
-        const B = new SwitchHost('B', 2, SpanningTreeProtocol.STP);
-        const C = new SwitchHost('C', 2, SpanningTreeProtocol.STP);
+    it('should select root port based on lowest cost', async () => {
+      // Use STP (not RPVST) for faster convergence in this specific test
+      const A = new SwitchHost('A', 2, SpanningTreeProtocol.STP);
+      const B = new SwitchHost('B', 2, SpanningTreeProtocol.STP);
+      const C = new SwitchHost('C', 2, SpanningTreeProtocol.STP);
 
-        A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
-        B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
-        C.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:03'));
+      A.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:01'));
+      B.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:02'));
+      C.getInterface(0).setMacAddress(new MacAddress('00:00:00:00:00:03'));
 
-        // Enable STP and interfaces
-        // eslint-disable-next-line no-restricted-syntax
-        for (const sw of [A, B, C]) {
-          sw.spanningTree.Enable = true;
-          sw.getInterface(0).up();
-          sw.getInterface(1).up();
-        }
+      // Enable STP and interfaces
+      // eslint-disable-next-line no-restricted-syntax
+      for (const sw of [A, B, C]) {
+        sw.spanningTree.Enable = true;
+        sw.getInterface(0).up();
+        sw.getInterface(1).up();
+      }
 
-        // C has two paths to A (root): C-A (direct) and C-B-A (indirect)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
-        const _AB = new Link(A.getInterface(0), B.getInterface(0));
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
-        const _CA = new Link(C.getInterface(0), A.getInterface(1));
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
-        const _BC = new Link(B.getInterface(1), C.getInterface(1));
+      // C has two paths to A (root): C-A (direct) and C-B-A (indirect)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+      const _AB = new Link(A.getInterface(0), B.getInterface(0));
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+      const _CA = new Link(C.getInterface(0), A.getInterface(1));
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+      const _BC = new Link(B.getInterface(1), C.getInterface(1));
 
-        // Wait for convergence with C selecting correct root port and blocking the other
-        await waitForConvergence(
-          () => {
-            if (!A.spanningTree.IsRoot) return false;
-            // C should select direct path to A as root port (lowest cost)
-            const caRole = C.spanningTree.Role(C.getInterface(0));
-            const cbRole = C.spanningTree.Role(C.getInterface(1));
-            const caCost = C.spanningTree.Cost(C.getInterface(0));
-            const cbCost = C.spanningTree.Cost(C.getInterface(1));
-            const cbBlocked =
-              cbRole === SpanningTreePortRole.Blocked ||
-              cbRole === SpanningTreePortRole.Alternate ||
-              cbRole === SpanningTreePortRole.Backup;
-            return (
-              caRole === SpanningTreePortRole.Root &&
-              caCost > 0 &&
-              caCost < cbCost &&
-              cbBlocked
-            );
-          },
-          [A, B, C],
-          10000
-        );
-
-        // C's root port should be the one connected to A directly (lower cost)
-        const caRole = C.spanningTree.Role(C.getInterface(0));
-        const cbRole = C.spanningTree.Role(C.getInterface(1));
-
-        expect(caRole).toBe(SpanningTreePortRole.Root); // Direct to A
-        expect(
-          cbRole === SpanningTreePortRole.Blocked ||
+      // Wait for convergence with C selecting correct root port and blocking the other
+      await waitForConvergence(
+        () => {
+          if (!A.spanningTree.IsRoot) return false;
+          // C should select direct path to A as root port (lowest cost)
+          const caRole = C.spanningTree.Role(C.getInterface(0));
+          const cbRole = C.spanningTree.Role(C.getInterface(1));
+          const caCost = C.spanningTree.Cost(C.getInterface(0));
+          const cbCost = C.spanningTree.Cost(C.getInterface(1));
+          const cbBlocked =
+            cbRole === SpanningTreePortRole.Blocked ||
             cbRole === SpanningTreePortRole.Alternate ||
-            cbRole === SpanningTreePortRole.Backup
-        ).toBe(true); // Indirect (blocked)
+            cbRole === SpanningTreePortRole.Backup;
+          return (
+            caRole === SpanningTreePortRole.Root &&
+            caCost > 0 &&
+            caCost < cbCost &&
+            cbBlocked
+          );
+        },
+        [A, B, C],
+        10000
+      );
 
-        [A, B, C].forEach((sw) => sw.destroy());
-      },
-      15000
-    ); // Increased timeout to 15s since convergence can take up to 10s
+      // C's root port should be the one connected to A directly (lower cost)
+      const caRole = C.spanningTree.Role(C.getInterface(0));
+      const cbRole = C.spanningTree.Role(C.getInterface(1));
+
+      expect(caRole).toBe(SpanningTreePortRole.Root); // Direct to A
+      expect(
+        cbRole === SpanningTreePortRole.Blocked ||
+          cbRole === SpanningTreePortRole.Alternate ||
+          cbRole === SpanningTreePortRole.Backup
+      ).toBe(true); // Indirect (blocked)
+
+      [A, B, C].forEach((sw) => sw.destroy());
+    }, 15000); // Increased timeout to 15s since convergence can take up to 10s
 
     // Note: Testing individual tie-breakers (sender priority, sender MAC, port IDs)
     // is difficult without mocking BPDU messages or controlling interface creation.

--- a/src/features/network-diagram/lib/pkt-parser/pka-test.test.ts
+++ b/src/features/network-diagram/lib/pkt-parser/pka-test.test.ts
@@ -14,34 +14,15 @@ describe('PKA file test', () => {
     const data = readFileSync(filepath);
     const buffer = new Uint8Array(data);
 
-    console.log('File size:', buffer.length);
-    console.log(
-      'First 20 bytes:',
-      Array.from(buffer.slice(0, 20))
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join(' ')
-    );
-
     const version = detectPacketTracerVersion(buffer);
-    console.log('Detected version:', version);
 
     const xml =
       version === '5.x'
         ? decryptPacketTracer5(buffer)
         : decryptPacketTracer7(buffer);
 
-    if (xml === null) {
-      console.log('❌ Decryption returned null (authentication failed)');
-    } else {
-      console.log('✅ Decrypted successfully');
-      console.log('XML length:', xml.length);
-      console.log('First 500 chars:', xml.substring(0, 500));
-      console.log('Contains PACKETTRACER:', xml.includes('<PACKETTRACER'));
-      console.log(
-        'Contains VERSION:',
-        xml.includes('<VERSION>') || xml.includes('VERSION=')
-      );
-      console.log('Contains NETWORK:', xml.includes('<NETWORK'));
-    }
+    // Silent test - just verify it doesn't crash
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    xml;
   });
 });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,9 +23,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    },
-
-    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [


### PR DESCRIPTION
- Remove test-related types from tsconfig.app.json (vitest/globals, @testing-library/jest-dom)
- Fix SpanningTreeProtocol usage: replace boolean (true/false) with proper enum values
- Add IPAddress.toNumber() method for IP checksum calculation
- Fix Node<T> generic type arguments with eslint-disable comments
- Change CableType from CableUIType to proper CableType in CreateLinkResult
- Fix SwitchHost import: change from 'import type' to regular import for instanceof checks
- Simplify SwitchHost constructor calls: use default RPVST for switches, only specify None for hubs
- Fix network context type narrowing in useStpService
- Auto-fix Prettier formatting issues in protocol files

All TypeScript compilation errors are now resolved. The build completes successfully.