### PR TITLE
Add BGP protocol to network diagram UI

### DIFF
--- a/src/features/network-diagram/components/config/BgpServiceConfig.tsx
+++ b/src/features/network-diagram/components/config/BgpServiceConfig.tsx
@@ -1,0 +1,428 @@
+/**
+ * BGP Service Configuration Component
+ * Provides UI for configuring BGP (Border Gateway Protocol) settings
+ */
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import type { RouterHost } from '../../lib/network-simulator/nodes/router';
+import type { Network } from '../../lib/network-simulator/network';
+import useBgpService from '../../hooks/useBgpService';
+
+interface BgpServiceConfigProps {
+  node: RouterHost;
+  network?: Network | null;
+}
+
+export default function BgpServiceConfig({
+  node,
+  network,
+}: BgpServiceConfigProps) {
+  const {
+    enabled,
+    setEnabled,
+    localAS,
+    setLocalAS,
+    getAllNeighbors,
+    getAllRoutes,
+    addNeighbor,
+    removeNeighbor,
+    getConfiguration,
+    updateConfiguration,
+    clearRoutes,
+    getRouterID,
+  } = useBgpService(node, network);
+
+  const neighbors = getAllNeighbors();
+  const routes = getAllRoutes();
+  const config = getConfiguration();
+  const routerID = getRouterID();
+
+  // Dialog state for adding neighbor
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newNeighborIP, setNewNeighborIP] = useState('');
+  const [newRemoteAS, setNewRemoteAS] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+
+  // Dialog state for removing neighbor
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [neighborToDelete, setNeighborToDelete] = useState<string | null>(null);
+
+  const handleAddNeighbor = () => {
+    try {
+      const asNumber = parseInt(newRemoteAS, 10);
+      if (Number.isNaN(asNumber) || asNumber < 0 || asNumber > 65535) {
+        alert('AS number must be between 0 and 65535');
+        return;
+      }
+
+      addNeighbor(newNeighborIP, asNumber, newDescription || undefined);
+      setDialogOpen(false);
+      setNewNeighborIP('');
+      setNewRemoteAS('');
+      setNewDescription('');
+    } catch (error) {
+      alert(`Failed to add neighbor: ${error}`);
+    }
+  };
+
+  const handleRemoveNeighbor = () => {
+    if (neighborToDelete) {
+      try {
+        removeNeighbor(neighborToDelete);
+        setDeleteDialogOpen(false);
+        setNeighborToDelete(null);
+      } catch (error) {
+        alert(`Failed to remove neighbor: ${error}`);
+      }
+    }
+  };
+
+  const handleClearRoutes = () => {
+    clearRoutes();
+  };
+
+  const handleLocalASChange = (value: string) => {
+    const asNumber = parseInt(value, 10);
+    if (!Number.isNaN(asNumber) && asNumber >= 0 && asNumber <= 65535) {
+      setLocalAS(asNumber);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>BGP Configuration</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="bgp-enable">Enable BGP Service</Label>
+              <p className="text-muted-foreground text-xs">
+                Activate Border Gateway Protocol for inter-domain routing
+              </p>
+            </div>
+            <Switch
+              id="bgp-enable"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="local-as">Local AS Number</Label>
+            <Input
+              id="local-as"
+              type="number"
+              min="0"
+              max="65535"
+              value={localAS}
+              onChange={(e) => handleLocalASChange(e.target.value)}
+              placeholder="65000"
+            />
+            <p className="text-muted-foreground text-xs">
+              Autonomous System number for this router (0-65535)
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Router ID</Label>
+            <p className="font-mono text-xs">{routerID}</p>
+            <p className="text-muted-foreground text-xs">
+              Automatically set to highest interface IP address
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Hold Time</Label>
+              <p className="text-muted-foreground text-xs">
+                {config.holdTime}s (session timeout)
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label>Keepalive Time</Label>
+              <p className="text-muted-foreground text-xs">
+                {config.keepaliveTime}s (keepalive interval)
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {enabled && (
+        <>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>BGP Neighbors</CardTitle>
+              <div className="flex gap-2">
+                <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+                  <DialogTrigger asChild>
+                    <Button variant="outline" size="sm">
+                      Add Neighbor
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Add BGP Neighbor</DialogTitle>
+                      <DialogDescription>
+                        Configure a new BGP peer relationship
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-4 py-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="neighbor-ip">Neighbor IP Address</Label>
+                        <Input
+                          id="neighbor-ip"
+                          value={newNeighborIP}
+                          onChange={(e) => setNewNeighborIP(e.target.value)}
+                          placeholder="192.168.1.1"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="remote-as">Remote AS Number</Label>
+                        <Input
+                          id="remote-as"
+                          type="number"
+                          min="0"
+                          max="65535"
+                          value={newRemoteAS}
+                          onChange={(e) => setNewRemoteAS(e.target.value)}
+                          placeholder="65001"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="description">
+                          Description (optional)
+                        </Label>
+                        <Input
+                          id="description"
+                          value={newDescription}
+                          onChange={(e) => setNewDescription(e.target.value)}
+                          placeholder="ISP Peer"
+                        />
+                      </div>
+                    </div>
+                    <DialogFooter>
+                      <Button
+                        variant="outline"
+                        onClick={() => setDialogOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button onClick={handleAddNeighbor}>Add Neighbor</Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+                {neighbors.length > 0 && (
+                  <Badge variant="secondary">
+                    {neighbors.filter((n) => n.state === 5).length} of{' '}
+                    {neighbors.length} established
+                  </Badge>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              {neighbors.length === 0 ? (
+                <p className="text-muted-foreground text-center py-4 text-sm">
+                  No BGP neighbors configured. Add a neighbor to start.
+                </p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Neighbor IP</TableHead>
+                      <TableHead>Remote AS</TableHead>
+                      <TableHead>State</TableHead>
+                      <TableHead>Prefixes</TableHead>
+                      <TableHead>Description</TableHead>
+                      <TableHead>Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {neighbors.map((neighbor) => (
+                      <TableRow key={neighbor.neighborIP}>
+                        <TableCell className="font-mono text-xs">
+                          {neighbor.neighborIP}
+                        </TableCell>
+                        <TableCell>{neighbor.remoteAS}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              neighbor.state === 5 ? 'default' : 'outline'
+                            }
+                          >
+                            {neighbor.stateName}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{neighbor.prefixesReceived}</TableCell>
+                        <TableCell className="text-muted-foreground text-xs">
+                          {neighbor.description || '-'}
+                        </TableCell>
+                        <TableCell>
+                          <Dialog
+                            open={
+                              deleteDialogOpen &&
+                              neighborToDelete === neighbor.neighborIP
+                            }
+                            onOpenChange={(open) => {
+                              setDeleteDialogOpen(open);
+                              if (!open) setNeighborToDelete(null);
+                            }}
+                          >
+                            <DialogTrigger asChild>
+                              <Button
+                                onClick={() =>
+                                  setNeighborToDelete(neighbor.neighborIP)
+                                }
+                                variant="ghost"
+                                size="sm"
+                              >
+                                Remove
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent>
+                              <DialogHeader>
+                                <DialogTitle>Remove BGP Neighbor</DialogTitle>
+                                <DialogDescription>
+                                  Are you sure you want to remove neighbor{' '}
+                                  {neighbor.neighborIP}? This will delete all
+                                  routes learned from this peer.
+                                </DialogDescription>
+                              </DialogHeader>
+                              <DialogFooter>
+                                <Button
+                                  variant="outline"
+                                  onClick={() => setDeleteDialogOpen(false)}
+                                >
+                                  Cancel
+                                </Button>
+                                <Button
+                                  variant="destructive"
+                                  onClick={handleRemoveNeighbor}
+                                >
+                                  Remove Neighbor
+                                </Button>
+                              </DialogFooter>
+                            </DialogContent>
+                          </Dialog>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>BGP Routing Table</CardTitle>
+              <div className="flex gap-2">
+                {routes.length > 0 && (
+                  <Button
+                    onClick={handleClearRoutes}
+                    variant="outline"
+                    size="sm"
+                  >
+                    Clear Routes
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              {routes.length === 0 ? (
+                <p className="text-muted-foreground text-center py-4 text-sm">
+                  {neighbors.length === 0
+                    ? 'Add BGP neighbors to start learning routes'
+                    : 'No BGP routes learned yet. Waiting for neighbor establishment...'}
+                </p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Network</TableHead>
+                      <TableHead>Next Hop</TableHead>
+                      <TableHead>From Neighbor</TableHead>
+                      <TableHead>Local Pref</TableHead>
+                      <TableHead>MED</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {routes.map((route) => (
+                      <TableRow
+                        key={`${route.network}/${route.prefixLength}-${route.nextHop}`}
+                      >
+                        <TableCell className="font-mono text-xs">
+                          {route.network}/{route.prefixLength}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {route.nextHop}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {route.fromNeighbor}
+                        </TableCell>
+                        <TableCell>{route.localPref}</TableCell>
+                        <TableCell>{route.med}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          {neighbors.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>BGP Statistics</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <span className="font-medium">Total Neighbors:</span>{' '}
+                    {neighbors.length}
+                  </div>
+                  <div>
+                    <span className="font-medium">Established:</span>{' '}
+                    {neighbors.filter((n) => n.state === 5).length}
+                  </div>
+                  <div>
+                    <span className="font-medium">Total Routes:</span>{' '}
+                    {routes.length}
+                  </div>
+                  <div>
+                    <span className="font-medium">Local AS:</span> {localAS}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/network-diagram/components/config/BgpServiceConfig.tsx
+++ b/src/features/network-diagram/components/config/BgpServiceConfig.tsx
@@ -50,7 +50,6 @@ export default function BgpServiceConfig({
     addNeighbor,
     removeNeighbor,
     getConfiguration,
-    updateConfiguration,
     clearRoutes,
     getRouterID,
   } = useBgpService(node, network);
@@ -74,6 +73,7 @@ export default function BgpServiceConfig({
     try {
       const asNumber = parseInt(newRemoteAS, 10);
       if (Number.isNaN(asNumber) || asNumber < 0 || asNumber > 65535) {
+        // eslint-disable-next-line no-alert
         alert('AS number must be between 0 and 65535');
         return;
       }
@@ -84,6 +84,7 @@ export default function BgpServiceConfig({
       setNewRemoteAS('');
       setNewDescription('');
     } catch (error) {
+      // eslint-disable-next-line no-alert
       alert(`Failed to add neighbor: ${error}`);
     }
   };
@@ -95,6 +96,7 @@ export default function BgpServiceConfig({
         setDeleteDialogOpen(false);
         setNeighborToDelete(null);
       } catch (error) {
+        // eslint-disable-next-line no-alert
         alert(`Failed to remove neighbor: ${error}`);
       }
     }

--- a/src/features/network-diagram/components/config/ServiceTab.tsx
+++ b/src/features/network-diagram/components/config/ServiceTab.tsx
@@ -16,6 +16,7 @@ import StpServiceConfig from './StpServiceConfig';
 import FhrpServiceConfig from './FhrpServiceConfig';
 import RipServiceConfig from './RipServiceConfig';
 import OspfServiceConfig from './OspfServiceConfig';
+import BgpServiceConfig from './BgpServiceConfig';
 
 interface ServiceTabProps {
   node: ServerHost | SwitchHost | RouterHost;
@@ -66,6 +67,12 @@ export default function ServiceTab({ node, network }: ServiceTabProps) {
             >
               OSPF
             </TabsTrigger>
+            <TabsTrigger
+              className="w-40 shrink-0 grow-0 justify-start"
+              value="bgp"
+            >
+              BGP
+            </TabsTrigger>
           </>
         )}
         {isServer && (
@@ -108,6 +115,9 @@ export default function ServiceTab({ node, network }: ServiceTabProps) {
             </TabsContent>
             <TabsContent value="ospf">
               <OspfServiceConfig node={node as RouterHost} network={network} />
+            </TabsContent>
+            <TabsContent value="bgp">
+              <BgpServiceConfig node={node as RouterHost} network={network} />
             </TabsContent>
           </>
         )}

--- a/src/features/network-diagram/hooks/useBgpService.ts
+++ b/src/features/network-diagram/hooks/useBgpService.ts
@@ -1,7 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { RouterHost } from '../lib/network-simulator/nodes/router';
 import type { Network } from '../lib/network-simulator/network';
-import type { BGPNeighbor, BGPRoute } from '../lib/network-simulator/services/bgp';
+import type {
+  BGPNeighbor,
+  BGPRoute,
+} from '../lib/network-simulator/services/bgp';
 import { IPAddress } from '../lib/network-simulator/address';
 import { BGPState } from '../lib/network-simulator/protocols/bgp';
 

--- a/src/features/network-diagram/hooks/useBgpService.ts
+++ b/src/features/network-diagram/hooks/useBgpService.ts
@@ -1,0 +1,209 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { RouterHost } from '../lib/network-simulator/nodes/router';
+import type { Network } from '../lib/network-simulator/network';
+import type { BGPNeighbor, BGPRoute } from '../lib/network-simulator/services/bgp';
+import { IPAddress } from '../lib/network-simulator/address';
+import { BGPState } from '../lib/network-simulator/protocols/bgp';
+
+export interface BGPNeighborInfo {
+  neighborIP: string;
+  remoteAS: number;
+  description: string;
+  state: BGPState;
+  stateName: string;
+  remoteRouterID: string | null;
+  holdTime: number;
+  keepaliveTime: number;
+  messagesReceived: number;
+  messagesSent: number;
+  prefixesReceived: number;
+  uptime: number;
+}
+
+export interface BGPRouteInfo {
+  network: string;
+  prefixLength: number;
+  nextHop: string;
+  asPath: number[];
+  localPref: number;
+  origin: number;
+  med: number;
+  fromNeighbor: string;
+  lastUpdate: number;
+}
+
+export interface BGPConfiguration {
+  enabled: boolean;
+  localAS: number;
+  routerID: string;
+  holdTime: number;
+  keepaliveTime: number;
+  neighbors: BGPNeighborInfo[];
+}
+
+export default function useBgpService(
+  node: RouterHost,
+  _network?: Network | null
+) {
+  const [enabled, setEnabled] = useState(node.services.bgp.Enable);
+  const [localAS, setLocalAS] = useState(node.services.bgp.localAS);
+
+  // Sync with backend when enabled changes
+  useEffect(() => {
+    // eslint-disable-next-line no-param-reassign
+    node.services.bgp.Enable = enabled;
+  }, [enabled, node]);
+
+  // Sync with backend when localAS changes
+  useEffect(() => {
+    // eslint-disable-next-line no-param-reassign
+    node.services.bgp.localAS = localAS;
+  }, [localAS, node]);
+
+  // Get all BGP neighbors
+  const getAllNeighbors = useCallback((): BGPNeighborInfo[] => {
+    const neighbors: BGPNeighborInfo[] = [];
+
+    node.services.bgp.getNeighbors().forEach((neighbor: BGPNeighbor) => {
+      neighbors.push({
+        neighborIP: neighbor.neighborIP.toString(),
+        remoteAS: neighbor.remoteAS,
+        description: neighbor.description,
+        state: neighbor.state,
+        stateName: BGPState[neighbor.state],
+        remoteRouterID: neighbor.remoteRouterID?.toString() || null,
+        holdTime: neighbor.holdTime,
+        keepaliveTime: neighbor.keepaliveTime,
+        messagesReceived: neighbor.messagesReceived,
+        messagesSent: neighbor.messagesSent,
+        prefixesReceived: neighbor.prefixesReceived,
+        uptime: neighbor.uptime,
+      });
+    });
+
+    return neighbors;
+  }, [node]);
+
+  // Get all BGP routes
+  const getAllRoutes = useCallback((): BGPRouteInfo[] => {
+    const routes: BGPRouteInfo[] = [];
+
+    node.services.bgp.getRoutes().forEach((route: BGPRoute) => {
+      routes.push({
+        network: route.network.toString(),
+        prefixLength: route.prefixLength,
+        nextHop: route.nextHop.toString(),
+        asPath: route.asPath,
+        localPref: route.localPref,
+        origin: route.origin,
+        med: route.med,
+        fromNeighbor: route.fromNeighbor.toString(),
+        lastUpdate: route.lastUpdate,
+      });
+    });
+
+    return routes;
+  }, [node]);
+
+  // Add a BGP neighbor
+  const addNeighbor = useCallback(
+    (neighborIP: string, remoteAS: number, description?: string) => {
+      const ip = new IPAddress(neighborIP);
+      node.services.bgp.addNeighbor(ip, remoteAS, description);
+    },
+    [node]
+  );
+
+  // Remove a BGP neighbor
+  const removeNeighbor = useCallback(
+    (neighborIP: string) => {
+      const ip = new IPAddress(neighborIP);
+      node.services.bgp.removeNeighbor(ip);
+    },
+    [node]
+  );
+
+  // Get neighbor by IP
+  const getNeighbor = useCallback(
+    (neighborIP: string): BGPNeighborInfo | null => {
+      const ip = new IPAddress(neighborIP);
+      const neighbor = node.services.bgp.getNeighbor(ip);
+
+      if (!neighbor) return null;
+
+      return {
+        neighborIP: neighbor.neighborIP.toString(),
+        remoteAS: neighbor.remoteAS,
+        description: neighbor.description,
+        state: neighbor.state,
+        stateName: BGPState[neighbor.state],
+        remoteRouterID: neighbor.remoteRouterID?.toString() || null,
+        holdTime: neighbor.holdTime,
+        keepaliveTime: neighbor.keepaliveTime,
+        messagesReceived: neighbor.messagesReceived,
+        messagesSent: neighbor.messagesSent,
+        prefixesReceived: neighbor.prefixesReceived,
+        uptime: neighbor.uptime,
+      };
+    },
+    [node]
+  );
+
+  // Get BGP configuration
+  const getConfiguration = useCallback(
+    (): BGPConfiguration => ({
+      enabled: node.services.bgp.Enable,
+      localAS: node.services.bgp.localAS,
+      routerID: node.services.bgp.routerID.toString(),
+      holdTime: node.services.bgp.holdTime,
+      keepaliveTime: node.services.bgp.keepaliveTime,
+      neighbors: getAllNeighbors(),
+    }),
+    [node, getAllNeighbors]
+  );
+
+  // Update BGP configuration
+  const updateConfiguration = useCallback(
+    (config: Partial<BGPConfiguration>) => {
+      if (config.localAS !== undefined) {
+        setLocalAS(config.localAS);
+      }
+      if (config.holdTime !== undefined) {
+        // eslint-disable-next-line no-param-reassign
+        node.services.bgp.holdTime = config.holdTime;
+      }
+      if (config.keepaliveTime !== undefined) {
+        // eslint-disable-next-line no-param-reassign
+        node.services.bgp.keepaliveTime = config.keepaliveTime;
+      }
+    },
+    [node]
+  );
+
+  // Clear all BGP routes
+  const clearRoutes = useCallback(() => {
+    node.services.bgp.clearRoutes();
+  }, [node]);
+
+  // Get Router ID
+  const getRouterID = useCallback(
+    (): string => node.services.bgp.routerID.toString(),
+    [node]
+  );
+
+  return {
+    enabled,
+    setEnabled,
+    localAS,
+    setLocalAS,
+    getAllNeighbors,
+    getAllRoutes,
+    addNeighbor,
+    removeNeighbor,
+    getNeighbor,
+    getConfiguration,
+    updateConfiguration,
+    clearRoutes,
+    getRouterID,
+  };
+}

--- a/src/features/network-diagram/lib/network-simulator/nodes/router.ts
+++ b/src/features/network-diagram/lib/network-simulator/nodes/router.ts
@@ -8,6 +8,7 @@ import { DhcpServer } from '../services/dhcp';
 import { FHRPService } from '../services/fhrp';
 import { RIPService } from '../services/rip';
 import { OSPFService } from '../services/ospf';
+import { BGPService } from '../services/bgp';
 import { NetworkHost } from './generic';
 import { NetworkMessage } from '../message';
 import type { NetworkInterface } from '../layers/network';
@@ -36,6 +37,7 @@ export class RouterHost extends NetworkHost implements NetworkListener {
     fhrp: FHRPService;
     rip: RIPService;
     ospf: OSPFService;
+    bgp: BGPService;
   };
 
   // Modern callback pattern instead of RxJS Subject
@@ -52,6 +54,7 @@ export class RouterHost extends NetworkHost implements NetworkListener {
       fhrp: new FHRPService(this),
       rip: new RIPService(this),
       ospf: new OSPFService(this, 1),
+      bgp: new BGPService(this, 65000),
     };
   }
 

--- a/src/features/network-diagram/lib/network-simulator/protocols/bgp.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/bgp.test.ts
@@ -38,9 +38,7 @@ describe('BGP protocol', () => {
       const bgpMsg = messages[0] as BGPMessage;
       expect(bgpMsg.type).toBe(BGPMessageType.Keepalive);
       expect(bgpMsg.length).toBe(19); // Minimum BGP header
-      expect(bgpMsg.marker).toBe(
-        BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
-      );
+      expect(bgpMsg.marker).toBe(BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'));
     });
 
     it('should set correct protocol for BGP (TCP)', () => {

--- a/src/features/network-diagram/lib/network-simulator/protocols/bgp.test.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/bgp.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  Scheduler,
+  SchedulerState,
+} from '@/features/network-diagram/lib/scheduler';
+import { IPAddress } from '../address';
+import {
+  BGPMessage,
+  BGPOpenMessage,
+  BGPUpdateMessage,
+  BGPNotificationMessage,
+  BGPMessageType,
+  BGPState,
+  BGPErrorCode,
+  BGP_VERSION,
+  BGP_DEFAULT_HOLD_TIME,
+  BGPNLRI,
+  BGPPathAttribute,
+} from './bgp';
+
+describe('BGP protocol', () => {
+  beforeEach(() => {
+    Scheduler.getInstance().Speed = SchedulerState.FASTER;
+  });
+
+  describe('BGPMessage Builder', () => {
+    it('should build basic BGP keepalive message', () => {
+      const builder = new BGPMessage.Builder()
+        .setBGPType(BGPMessageType.Keepalive)
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'));
+
+      const messages = builder.build();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(BGPMessage);
+
+      const bgpMsg = messages[0] as BGPMessage;
+      expect(bgpMsg.type).toBe(BGPMessageType.Keepalive);
+      expect(bgpMsg.length).toBe(19); // Minimum BGP header
+      expect(bgpMsg.marker).toBe(
+        BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
+      );
+    });
+
+    it('should set correct protocol for BGP (TCP)', () => {
+      const builder = new BGPMessage.Builder()
+        .setNetSource(new IPAddress('10.0.0.1'))
+        .setNetDestination(new IPAddress('10.0.0.2'));
+
+      const messages = builder.build();
+      const bgpMsg = messages[0] as BGPMessage;
+
+      expect(bgpMsg.protocol).toBe(6); // TCP
+    });
+  });
+
+  describe('BGPOpenMessage Builder', () => {
+    it('should build BGP OPEN message with required fields', () => {
+      const builder = new BGPOpenMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .setMyAutonomousSystem(65000)
+        .setHoldTime(180)
+        .setBGPIdentifier(new IPAddress('1.1.1.1'));
+
+      const messages = builder.build();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(BGPOpenMessage);
+
+      const openMsg = messages[0] as BGPOpenMessage;
+      expect(openMsg.type).toBe(BGPMessageType.Open);
+      expect(openMsg.version).toBe(BGP_VERSION);
+      expect(openMsg.myAutonomousSystem).toBe(65000);
+      expect(openMsg.holdTime).toBe(180);
+      expect(openMsg.bgpIdentifier.toString()).toBe('1.1.1.1');
+    });
+
+    it('should validate BGP version', () => {
+      const builder = new BGPOpenMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'));
+
+      expect(() => builder.setVersion(3)).toThrow('BGP version must be 4');
+    });
+
+    it('should validate AS number range', () => {
+      const builder = new BGPOpenMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'));
+
+      expect(() => builder.setMyAutonomousSystem(-1)).toThrow(
+        'AS number must be between 0 and 65535'
+      );
+      expect(() => builder.setMyAutonomousSystem(65536)).toThrow(
+        'AS number must be between 0 and 65535'
+      );
+    });
+
+    it('should validate hold time', () => {
+      const builder = new BGPOpenMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'));
+
+      expect(() => builder.setHoldTime(2)).toThrow(
+        'Hold time must be 0 or between 3 and 65535 seconds'
+      );
+
+      // Valid values
+      expect(() => builder.setHoldTime(0)).not.toThrow();
+      expect(() => builder.setHoldTime(3)).not.toThrow();
+      expect(() => builder.setHoldTime(180)).not.toThrow();
+    });
+
+    it('should format OPEN message toString with AS number', () => {
+      const openMsg = new BGPOpenMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .setMyAutonomousSystem(65001)
+        .setBGPIdentifier(new IPAddress('1.1.1.1'))
+        .build()[0] as BGPOpenMessage;
+
+      const str = openMsg.toString();
+      expect(str).toContain('BGP');
+      expect(str).toContain('OPEN');
+      expect(str).toContain('65001');
+    });
+  });
+
+  describe('BGPUpdateMessage Builder', () => {
+    it('should build BGP UPDATE message with advertised routes', () => {
+      const nlri1 = new BGPNLRI(new IPAddress('192.168.1.0'), 24);
+      const nlri2 = new BGPNLRI(new IPAddress('10.0.0.0'), 8);
+
+      const pathAttr = new BGPPathAttribute(0x40, 2, [65000]);
+
+      const builder = new BGPUpdateMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .addNLRI(nlri1)
+        .addNLRI(nlri2)
+        .addPathAttribute(pathAttr);
+
+      const messages = builder.build();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(BGPUpdateMessage);
+
+      const updateMsg = messages[0] as BGPUpdateMessage;
+      expect(updateMsg.type).toBe(BGPMessageType.Update);
+      expect(updateMsg.nlri).toHaveLength(2);
+      expect(updateMsg.nlri[0].prefix.toString()).toBe('192.168.1.0');
+      expect(updateMsg.nlri[0].prefixLength).toBe(24);
+      expect(updateMsg.pathAttributes).toHaveLength(1);
+    });
+
+    it('should build BGP UPDATE message with withdrawn routes', () => {
+      const withdrawn1 = new BGPNLRI(new IPAddress('172.16.0.0'), 16);
+      const withdrawn2 = new BGPNLRI(new IPAddress('192.168.0.0'), 16);
+
+      const builder = new BGPUpdateMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .addWithdrawnRoute(withdrawn1)
+        .addWithdrawnRoute(withdrawn2);
+
+      const messages = builder.build();
+
+      expect(messages).toHaveLength(1);
+
+      const updateMsg = messages[0] as BGPUpdateMessage;
+      expect(updateMsg.withdrawnRoutes).toHaveLength(2);
+      expect(updateMsg.withdrawnRoutes[0].prefix.toString()).toBe('172.16.0.0');
+      expect(updateMsg.withdrawnRoutes[0].prefixLength).toBe(16);
+    });
+
+    it('should format UPDATE message toString with counts', () => {
+      const nlri1 = new BGPNLRI(new IPAddress('192.168.1.0'), 24);
+      const withdrawn1 = new BGPNLRI(new IPAddress('172.16.0.0'), 16);
+
+      const updateMsg = new BGPUpdateMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .addNLRI(nlri1)
+        .addWithdrawnRoute(withdrawn1)
+        .build()[0] as BGPUpdateMessage;
+
+      const str = updateMsg.toString();
+      expect(str).toContain('BGP');
+      expect(str).toContain('UPDATE');
+      expect(str).toContain('+1'); // 1 advertised
+      expect(str).toContain('-1'); // 1 withdrawn
+    });
+  });
+
+  describe('BGPNotificationMessage Builder', () => {
+    it('should build BGP NOTIFICATION message', () => {
+      const builder = new BGPNotificationMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .setErrorCode(BGPErrorCode.HoldTimerExpired)
+        .setErrorSubcode(0);
+
+      const messages = builder.build();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBeInstanceOf(BGPNotificationMessage);
+
+      const notifMsg = messages[0] as BGPNotificationMessage;
+      expect(notifMsg.type).toBe(BGPMessageType.Notification);
+      expect(notifMsg.errorCode).toBe(BGPErrorCode.HoldTimerExpired);
+      expect(notifMsg.errorSubcode).toBe(0);
+    });
+
+    it('should include data in NOTIFICATION message', () => {
+      const errorData = [1, 2, 3, 4];
+
+      const builder = new BGPNotificationMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .setErrorCode(BGPErrorCode.OpenMessageError)
+        .setErrorSubcode(2)
+        .setData(errorData);
+
+      const messages = builder.build();
+      const notifMsg = messages[0] as BGPNotificationMessage;
+
+      expect(notifMsg.data).toEqual(errorData);
+      expect(notifMsg.length).toBe(19 + 2 + errorData.length); // header + error fields + data
+    });
+
+    it('should format NOTIFICATION message toString with error name', () => {
+      const notifMsg = new BGPNotificationMessage.Builder()
+        .setNetSource(new IPAddress('192.168.1.1'))
+        .setNetDestination(new IPAddress('192.168.1.2'))
+        .setErrorCode(BGPErrorCode.Cease)
+        .setErrorSubcode(0)
+        .build()[0] as BGPNotificationMessage;
+
+      const str = notifMsg.toString();
+      expect(str).toContain('BGP');
+      expect(str).toContain('NOTIFICATION');
+      expect(str).toContain('Cease');
+    });
+  });
+
+  describe('BGPNLRI', () => {
+    it('should create NLRI with prefix and length', () => {
+      const nlri = new BGPNLRI(new IPAddress('192.168.1.0'), 24);
+
+      expect(nlri.prefix.toString()).toBe('192.168.1.0');
+      expect(nlri.prefixLength).toBe(24);
+    });
+
+    it('should format NLRI as CIDR notation', () => {
+      const nlri = new BGPNLRI(new IPAddress('10.0.0.0'), 8);
+
+      const str = nlri.toString();
+      expect(str).toBe('10.0.0.0/8');
+    });
+  });
+
+  describe('BGPPathAttribute', () => {
+    it('should create path attribute with flags and type', () => {
+      const attr = new BGPPathAttribute(0x40, 2, [65000, 65001]);
+
+      expect(attr.flags).toBe(0x40);
+      expect(attr.typeCode).toBe(2);
+      expect(attr.value).toEqual([65000, 65001]);
+    });
+
+    it('should format path attribute as string', () => {
+      const attr = new BGPPathAttribute(0x40, 1, [100]);
+
+      const str = attr.toString();
+      expect(str).toContain('Attr');
+      expect(str).toContain('type=1');
+      expect(str).toContain('len=1');
+    });
+  });
+
+  describe('BGP Constants', () => {
+    it('should have correct BGP version', () => {
+      expect(BGP_VERSION).toBe(4);
+    });
+
+    it('should have correct default hold time', () => {
+      expect(BGP_DEFAULT_HOLD_TIME).toBe(180);
+    });
+
+    it('should have all BGP states defined', () => {
+      expect(BGPState.Idle).toBe(0);
+      expect(BGPState.Connect).toBe(1);
+      expect(BGPState.Active).toBe(2);
+      expect(BGPState.OpenSent).toBe(3);
+      expect(BGPState.OpenConfirm).toBe(4);
+      expect(BGPState.Established).toBe(5);
+    });
+
+    it('should have all BGP message types defined', () => {
+      expect(BGPMessageType.Open).toBe(1);
+      expect(BGPMessageType.Update).toBe(2);
+      expect(BGPMessageType.Notification).toBe(3);
+      expect(BGPMessageType.Keepalive).toBe(4);
+    });
+
+    it('should have all BGP error codes defined', () => {
+      expect(BGPErrorCode.MessageHeaderError).toBe(1);
+      expect(BGPErrorCode.OpenMessageError).toBe(2);
+      expect(BGPErrorCode.UpdateMessageError).toBe(3);
+      expect(BGPErrorCode.HoldTimerExpired).toBe(4);
+      expect(BGPErrorCode.FiniteStateMachineError).toBe(5);
+      expect(BGPErrorCode.Cease).toBe(6);
+    });
+  });
+});

--- a/src/features/network-diagram/lib/network-simulator/protocols/bgp.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/bgp.ts
@@ -225,9 +225,7 @@ export class BGPOpenMessage extends BGPMessage {
 
     public setHoldTime(holdTime: number): this {
       if (holdTime !== 0 && (holdTime < 3 || holdTime > 65535)) {
-        throw new Error(
-          'Hold time must be 0 or between 3 and 65535 seconds'
-        );
+        throw new Error('Hold time must be 0 or between 3 and 65535 seconds');
       }
       this.holdTime = holdTime;
       return this;

--- a/src/features/network-diagram/lib/network-simulator/protocols/bgp.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/bgp.ts
@@ -92,8 +92,13 @@ export class BGPMessage extends IPv4Message {
   // RFC 4271: Marker field (16 bytes, all ones for authentication compatibility)
   public marker: bigint = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
 
+  // RFC 4271: Message length field
+  protected bgpLength: number = 19; // Minimum header size
+
   // RFC 4271: Total length of message including header (bytes)
-  public length: number = 19; // Minimum header size
+  public override get length(): number {
+    return this.bgpLength;
+  }
 
   // RFC 4271: Message type
   public type: BGPMessageType = BGPMessageType.Keepalive;
@@ -136,7 +141,7 @@ export class BGPMessage extends IPv4Message {
       // Set BGP-specific fields
       message.marker = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
       message.type = this.bgpType;
-      message.length = 19; // Minimum BGP header
+      message.bgpLength = 19; // Minimum BGP header
 
       // Set IPv4 fields
       message.ttl = this.ttl;
@@ -263,7 +268,7 @@ export class BGPOpenMessage extends BGPMessage {
 
       // Calculate BGP message length
       // 19 (header) + 10 (OPEN fixed fields) + optional parameters length
-      message.length = 19 + 10 + message.optionalParametersLength;
+      message.bgpLength = 19 + 10 + message.optionalParametersLength;
 
       // Set IPv4 fields
       message.ttl = this.ttl;
@@ -375,7 +380,7 @@ export class BGPUpdateMessage extends BGPMessage {
       const nlriLength = this.nlriList.length * 5; // Approximate
 
       // Calculate BGP message length
-      message.length =
+      message.bgpLength =
         19 + 2 + withdrawnLength + 2 + pathAttrLength + nlriLength;
 
       // Set IPv4 fields
@@ -465,7 +470,7 @@ export class BGPNotificationMessage extends BGPMessage {
 
       // Calculate BGP message length
       // 19 (header) + 2 (error code + subcode) + data length
-      message.length = 19 + 2 + this.errData.length;
+      message.bgpLength = 19 + 2 + this.errData.length;
 
       // Set IPv4 fields
       message.ttl = this.ttl;

--- a/src/features/network-diagram/lib/network-simulator/protocols/bgp.ts
+++ b/src/features/network-diagram/lib/network-simulator/protocols/bgp.ts
@@ -1,0 +1,527 @@
+import { IPAddress } from '../address';
+import type { NetworkInterface } from '../layers/network';
+import { type NetworkMessage, type Payload } from '../message';
+import { IPv4Message } from './ipv4';
+import { ActionHandle, type NetworkListener } from './base';
+
+// RFC 4271: BGP Message Types
+export enum BGPMessageType {
+  Open = 1, // Establish BGP session
+  Update = 2, // Exchange routing information
+  Notification = 3, // Report errors
+  Keepalive = 4, // Maintain session
+}
+
+// RFC 4271: BGP Finite State Machine
+export enum BGPState {
+  Idle = 0, // Initial state, refusing connections
+  Connect = 1, // Waiting for TCP connection to complete
+  Active = 2, // Trying to acquire peer by initiating TCP connection
+  OpenSent = 3, // Waiting for OPEN message from peer
+  OpenConfirm = 4, // Waiting for KEEPALIVE or NOTIFICATION
+  Established = 5, // Peers can exchange UPDATE, KEEPALIVE and NOTIFICATION
+}
+
+// RFC 4271: BGP uses TCP port 179
+export const BGP_TCP_PORT = 179;
+
+// RFC 4271: BGP version 4
+export const BGP_VERSION = 4;
+
+// RFC 4271: Default timers (in seconds)
+export const BGP_DEFAULT_HOLD_TIME = 180; // Hold timer (3 minutes)
+export const BGP_DEFAULT_KEEPALIVE_TIME = 60; // Keepalive timer (1 minute, typically 1/3 of hold time)
+export const BGP_DEFAULT_CONNECT_RETRY_TIME = 120; // Connect retry timer (2 minutes)
+
+// RFC 4271: BGP Error Codes
+export enum BGPErrorCode {
+  MessageHeaderError = 1,
+  OpenMessageError = 2,
+  UpdateMessageError = 3,
+  HoldTimerExpired = 4,
+  FiniteStateMachineError = 5,
+  Cease = 6,
+}
+
+/**
+ * RFC 4271: BGP Path Attribute
+ * Represents a single path attribute in BGP UPDATE messages
+ */
+export class BGPPathAttribute {
+  public flags: number = 0; // Attribute flags (Optional, Transitive, Partial, Extended Length)
+
+  public typeCode: number = 0; // Attribute type code
+
+  public value: number[] = []; // Attribute value
+
+  constructor(flags?: number, typeCode?: number, value?: number[]) {
+    if (flags !== undefined) this.flags = flags;
+    if (typeCode !== undefined) this.typeCode = typeCode;
+    if (value !== undefined) this.value = value;
+  }
+
+  public toString(): string {
+    return `Attr(type=${this.typeCode}, len=${this.value.length})`;
+  }
+}
+
+/**
+ * RFC 4271: BGP NLRI (Network Layer Reachability Information)
+ * Represents advertised or withdrawn routes
+ */
+export class BGPNLRI {
+  public prefix: IPAddress;
+
+  public prefixLength: number; // CIDR prefix length
+
+  constructor(prefix: IPAddress, prefixLength: number) {
+    this.prefix = prefix;
+    this.prefixLength = prefixLength;
+  }
+
+  public toString(): string {
+    return `${this.prefix.toString()}/${this.prefixLength}`;
+  }
+}
+
+/**
+ * RFC 4271: BGP Message Base Class
+ * All BGP messages share a common header
+ */
+export class BGPMessage extends IPv4Message {
+  // RFC 4271: Marker field (16 bytes, all ones for authentication compatibility)
+  public marker: bigint = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
+
+  // RFC 4271: Total length of message including header (bytes)
+  public length: number = 19; // Minimum header size
+
+  // RFC 4271: Message type
+  public type: BGPMessageType = BGPMessageType.Keepalive;
+
+  protected constructor(
+    payload: Payload | string,
+    netSrc: IPAddress,
+    netDst: IPAddress | null
+  ) {
+    super(payload, netSrc, netDst);
+    // RFC 4271: BGP uses TCP (IP protocol number 6)
+    this.protocol = 6;
+  }
+
+  public override toString(): string {
+    const typeName = BGPMessageType[this.type];
+    return `BGP\n${typeName}`;
+  }
+
+  public override checksum(): number {
+    // BGP relies on TCP checksum
+    return super.checksum();
+  }
+
+  public static override Builder = class extends IPv4Message.Builder {
+    protected bgpType: BGPMessageType = BGPMessageType.Keepalive;
+
+    public setBGPType(type: BGPMessageType): this {
+      this.bgpType = type;
+      return this;
+    }
+
+    public override build(): IPv4Message[] {
+      if (this.netSrc === null) throw new Error('Source address is not set');
+      if (this.netDst === null)
+        throw new Error('Destination address is not set');
+
+      const message = new BGPMessage(this.payload, this.netSrc, this.netDst);
+
+      // Set BGP-specific fields
+      message.marker = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
+      message.type = this.bgpType;
+      message.length = 19; // Minimum BGP header
+
+      // Set IPv4 fields
+      message.ttl = this.ttl;
+      message.protocol = 6; // TCP
+      message.TOS = this.service;
+      message.identification = this.id;
+
+      // Calculate total length (IPv4 header + TCP header + BGP message)
+      // Simplified: 20 (IPv4) + 20 (TCP) + 19 (BGP header)
+      message.totalLength = 20 + 20 + message.length;
+
+      message.headerChecksum = message.checksum();
+
+      return [message];
+    }
+  };
+}
+
+/**
+ * RFC 4271: BGP OPEN Message
+ * Used to establish a BGP session between peers
+ */
+export class BGPOpenMessage extends BGPMessage {
+  // RFC 4271: BGP version (must be 4)
+  public version: number = BGP_VERSION;
+
+  // RFC 4271: Autonomous System number of sender
+  public myAutonomousSystem: number = 0;
+
+  // RFC 4271: Hold time proposed by sender (seconds)
+  public holdTime: number = BGP_DEFAULT_HOLD_TIME;
+
+  // RFC 4271: BGP Identifier (Router ID) - typically router's highest IP
+  public bgpIdentifier: IPAddress = new IPAddress('0.0.0.0');
+
+  // RFC 4271: Optional parameters length
+  public optionalParametersLength: number = 0;
+
+  // RFC 4271: Optional parameters (capabilities, etc.)
+  public optionalParameters: number[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(
+    payload: Payload | string,
+    netSrc: IPAddress,
+    netDst: IPAddress | null
+  ) {
+    super(payload, netSrc, netDst);
+  }
+
+  public override toString(): string {
+    return `BGP\nOPEN (AS ${this.myAutonomousSystem})`;
+  }
+
+  public static override Builder = class extends BGPMessage.Builder {
+    protected version: number = BGP_VERSION;
+
+    protected myAS: number = 0;
+
+    protected holdTime: number = BGP_DEFAULT_HOLD_TIME;
+
+    protected bgpID: IPAddress = new IPAddress('0.0.0.0');
+
+    protected optParams: number[] = [];
+
+    public setVersion(version: number): this {
+      if (version !== 4) {
+        throw new Error('BGP version must be 4');
+      }
+      this.version = version;
+      return this;
+    }
+
+    public setMyAutonomousSystem(asNumber: number): this {
+      if (asNumber < 0 || asNumber > 65535) {
+        throw new Error('AS number must be between 0 and 65535');
+      }
+      this.myAS = asNumber;
+      return this;
+    }
+
+    public setHoldTime(holdTime: number): this {
+      if (holdTime !== 0 && (holdTime < 3 || holdTime > 65535)) {
+        throw new Error(
+          'Hold time must be 0 or between 3 and 65535 seconds'
+        );
+      }
+      this.holdTime = holdTime;
+      return this;
+    }
+
+    public setBGPIdentifier(routerID: IPAddress): this {
+      this.bgpID = routerID;
+      return this;
+    }
+
+    public setOptionalParameters(params: number[]): this {
+      this.optParams = params;
+      return this;
+    }
+
+    public override build(): IPv4Message[] {
+      if (this.netSrc === null) throw new Error('Source address is not set');
+      if (this.netDst === null)
+        throw new Error('Destination address is not set');
+
+      const message = new BGPOpenMessage(
+        this.payload,
+        this.netSrc,
+        this.netDst
+      );
+
+      // Set BGP base fields
+      message.marker = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
+      message.type = BGPMessageType.Open;
+
+      // Set OPEN-specific fields
+      message.version = this.version;
+      message.myAutonomousSystem = this.myAS;
+      message.holdTime = this.holdTime;
+      message.bgpIdentifier = this.bgpID;
+      message.optionalParameters = [...this.optParams];
+      message.optionalParametersLength = this.optParams.length;
+
+      // Calculate BGP message length
+      // 19 (header) + 10 (OPEN fixed fields) + optional parameters length
+      message.length = 19 + 10 + message.optionalParametersLength;
+
+      // Set IPv4 fields
+      message.ttl = this.ttl;
+      message.protocol = 6; // TCP
+      message.TOS = this.service;
+      message.identification = this.id;
+
+      message.totalLength = 20 + 20 + message.length;
+
+      message.headerChecksum = message.checksum();
+
+      return [message];
+    }
+  };
+}
+
+/**
+ * RFC 4271: BGP UPDATE Message
+ * Used to advertise or withdraw routes
+ */
+export class BGPUpdateMessage extends BGPMessage {
+  // RFC 4271: Withdrawn routes (routes that are no longer available)
+  public withdrawnRoutes: BGPNLRI[] = [];
+
+  // RFC 4271: Path attributes for advertised routes
+  public pathAttributes: BGPPathAttribute[] = [];
+
+  // RFC 4271: Network Layer Reachability Information (advertised routes)
+  public nlri: BGPNLRI[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(
+    payload: Payload | string,
+    netSrc: IPAddress,
+    netDst: IPAddress | null
+  ) {
+    super(payload, netSrc, netDst);
+  }
+
+  public override toString(): string {
+    const nlriCount = this.nlri.length;
+    const withdrawnCount = this.withdrawnRoutes.length;
+    return `BGP\nUPDATE (+${nlriCount}/-${withdrawnCount})`;
+  }
+
+  public static override Builder = class extends BGPMessage.Builder {
+    protected withdrawn: BGPNLRI[] = [];
+
+    protected pathAttrs: BGPPathAttribute[] = [];
+
+    protected nlriList: BGPNLRI[] = [];
+
+    public addWithdrawnRoute(route: BGPNLRI): this {
+      this.withdrawn.push(route);
+      return this;
+    }
+
+    public setWithdrawnRoutes(routes: BGPNLRI[]): this {
+      this.withdrawn = [...routes];
+      return this;
+    }
+
+    public addPathAttribute(attr: BGPPathAttribute): this {
+      this.pathAttrs.push(attr);
+      return this;
+    }
+
+    public setPathAttributes(attrs: BGPPathAttribute[]): this {
+      this.pathAttrs = [...attrs];
+      return this;
+    }
+
+    public addNLRI(nlri: BGPNLRI): this {
+      this.nlriList.push(nlri);
+      return this;
+    }
+
+    public setNLRI(nlriList: BGPNLRI[]): this {
+      this.nlriList = [...nlriList];
+      return this;
+    }
+
+    public override build(): IPv4Message[] {
+      if (this.netSrc === null) throw new Error('Source address is not set');
+      if (this.netDst === null)
+        throw new Error('Destination address is not set');
+
+      const message = new BGPUpdateMessage(
+        this.payload,
+        this.netSrc,
+        this.netDst
+      );
+
+      // Set BGP base fields
+      message.marker = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
+      message.type = BGPMessageType.Update;
+
+      // Set UPDATE-specific fields
+      message.withdrawnRoutes = [...this.withdrawn];
+      message.pathAttributes = [...this.pathAttrs];
+      message.nlri = [...this.nlriList];
+
+      // Calculate variable field lengths (simplified)
+      const withdrawnLength = this.withdrawn.length * 5; // Approximate
+      const pathAttrLength = this.pathAttrs.reduce(
+        (sum, attr) => sum + attr.value.length + 3,
+        0
+      );
+      const nlriLength = this.nlriList.length * 5; // Approximate
+
+      // Calculate BGP message length
+      message.length =
+        19 + 2 + withdrawnLength + 2 + pathAttrLength + nlriLength;
+
+      // Set IPv4 fields
+      message.ttl = this.ttl;
+      message.protocol = 6; // TCP
+      message.TOS = this.service;
+      message.identification = this.id;
+
+      message.totalLength = 20 + 20 + message.length;
+
+      message.headerChecksum = message.checksum();
+
+      return [message];
+    }
+  };
+}
+
+/**
+ * RFC 4271: BGP NOTIFICATION Message
+ * Used to report errors and close sessions
+ */
+export class BGPNotificationMessage extends BGPMessage {
+  // RFC 4271: Error code
+  public errorCode: BGPErrorCode = BGPErrorCode.Cease;
+
+  // RFC 4271: Error subcode
+  public errorSubcode: number = 0;
+
+  // RFC 4271: Diagnostic data
+  public data: number[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(
+    payload: Payload | string,
+    netSrc: IPAddress,
+    netDst: IPAddress | null
+  ) {
+    super(payload, netSrc, netDst);
+  }
+
+  public override toString(): string {
+    const errorName = BGPErrorCode[this.errorCode] || 'Unknown';
+    return `BGP\nNOTIFICATION (${errorName})`;
+  }
+
+  public static override Builder = class extends BGPMessage.Builder {
+    protected errCode: BGPErrorCode = BGPErrorCode.Cease;
+
+    protected errSubcode: number = 0;
+
+    protected errData: number[] = [];
+
+    public setErrorCode(code: BGPErrorCode): this {
+      this.errCode = code;
+      return this;
+    }
+
+    public setErrorSubcode(subcode: number): this {
+      this.errSubcode = subcode;
+      return this;
+    }
+
+    public setData(data: number[]): this {
+      this.errData = [...data];
+      return this;
+    }
+
+    public override build(): IPv4Message[] {
+      if (this.netSrc === null) throw new Error('Source address is not set');
+      if (this.netDst === null)
+        throw new Error('Destination address is not set');
+
+      const message = new BGPNotificationMessage(
+        this.payload,
+        this.netSrc,
+        this.netDst
+      );
+
+      // Set BGP base fields
+      message.marker = BigInt('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF');
+      message.type = BGPMessageType.Notification;
+
+      // Set NOTIFICATION-specific fields
+      message.errorCode = this.errCode;
+      message.errorSubcode = this.errSubcode;
+      message.data = [...this.errData];
+
+      // Calculate BGP message length
+      // 19 (header) + 2 (error code + subcode) + data length
+      message.length = 19 + 2 + this.errData.length;
+
+      // Set IPv4 fields
+      message.ttl = this.ttl;
+      message.protocol = 6; // TCP
+      message.TOS = this.service;
+      message.identification = this.id;
+
+      message.totalLength = 20 + 20 + message.length;
+
+      message.headerChecksum = message.checksum();
+
+      return [message];
+    }
+  };
+}
+
+/**
+ * RFC 4271: BGP Protocol Listener
+ * Validates incoming BGP messages
+ */
+export class BGPProtocol implements NetworkListener {
+  private iface: NetworkInterface;
+
+  private cleanupTimer: (() => void) | null = null;
+
+  constructor(iface: NetworkInterface) {
+    this.iface = iface;
+    iface.addListener(this);
+  }
+
+  public destroy(): void {
+    if (this.cleanupTimer) {
+      this.cleanupTimer();
+      this.cleanupTimer = null;
+    }
+  }
+
+  public receivePacket(message: NetworkMessage): ActionHandle {
+    if (message instanceof BGPMessage) {
+      // RFC 4271: Verify BGP version in OPEN messages
+      if (message instanceof BGPOpenMessage) {
+        if (message.version !== BGP_VERSION) {
+          // Drop invalid version packets
+          return ActionHandle.Stop;
+        }
+      }
+
+      // Check if this message is destined for this interface
+      if (message.netDst && !this.iface.hasNetAddress(message.netDst)) {
+        return ActionHandle.Continue;
+      }
+
+      // Message is valid BGP packet, continue processing in BGP service
+      return ActionHandle.Continue;
+    }
+
+    return ActionHandle.Continue;
+  }
+}

--- a/src/features/network-diagram/lib/network-simulator/services/bgp.ts
+++ b/src/features/network-diagram/lib/network-simulator/services/bgp.ts
@@ -254,7 +254,7 @@ export class BGPService
           }
         }
       });
-      routesToRemove.forEach((key) => this.bgpRoutes.delete(key));
+      routesToRemove.forEach((routeKey) => this.bgpRoutes.delete(routeKey));
     }
   }
 
@@ -400,6 +400,7 @@ export class BGPService
   /**
    * Reset neighbor to Idle state
    */
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   private resetNeighbor(neighbor: BGPNeighbor): void {
     // Stop all timers
     if (neighbor.connectRetryTimer) {
@@ -521,7 +522,9 @@ export class BGPService
     neighborIP: IPAddress
   ): NetworkInterface | null {
     // Check all interfaces to find one in the same subnet as neighbor
-    for (const ifaceName of this.host.getInterfaces()) {
+    const interfaces = this.host.getInterfaces();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const ifaceName of interfaces) {
       const iface = this.host.getInterface(ifaceName);
       const ifaceIP = iface.getNetAddress() as IPAddress;
       const ifaceMask = iface.getNetMask() as IPAddress;
@@ -627,7 +630,10 @@ export class BGPService
   /**
    * Process BGP UPDATE message
    */
-  private processUpdate(message: BGPUpdateMessage, neighbor: BGPNeighbor): void {
+  private processUpdate(
+    message: BGPUpdateMessage,
+    neighbor: BGPNeighbor
+  ): void {
     if (neighbor.state !== BGPState.Established) {
       return;
     }

--- a/src/features/network-diagram/lib/network-simulator/services/bgp.ts
+++ b/src/features/network-diagram/lib/network-simulator/services/bgp.ts
@@ -1,0 +1,710 @@
+/* eslint-disable no-param-reassign */
+import { Scheduler } from '@/features/network-diagram/lib/scheduler';
+import { IPAddress } from '../address';
+import type { NetworkInterface } from '../layers/network';
+import { type NetworkMessage } from '../message';
+import { ActionHandle, type NetworkListener } from '../protocols/base';
+import {
+  BGPMessage,
+  BGPOpenMessage,
+  BGPUpdateMessage,
+  BGPNotificationMessage,
+  BGPMessageType,
+  BGPState,
+  BGP_DEFAULT_HOLD_TIME,
+  BGP_DEFAULT_KEEPALIVE_TIME,
+  BGP_DEFAULT_CONNECT_RETRY_TIME,
+  BGPErrorCode,
+  BGPNLRI,
+  BGPPathAttribute,
+} from '../protocols/bgp';
+import { NetworkServices } from './dhcp';
+import type { RouterHost } from '../nodes/router';
+
+/**
+ * BGP Neighbor Configuration and State
+ * Represents a configured BGP peer relationship
+ */
+export class BGPNeighbor {
+  // Configuration
+  public neighborIP: IPAddress;
+
+  public remoteAS: number;
+
+  public description: string = '';
+
+  // State
+  public state: BGPState = BGPState.Idle;
+
+  public remoteRouterID: IPAddress | null = null;
+
+  public holdTime: number = BGP_DEFAULT_HOLD_TIME;
+
+  public keepaliveTime: number = BGP_DEFAULT_KEEPALIVE_TIME;
+
+  public connectRetryTime: number = BGP_DEFAULT_CONNECT_RETRY_TIME;
+
+  // Timers
+  public lastKeepalive: number = 0;
+
+  public lastUpdate: number = 0;
+
+  public connectRetryTimer: (() => void) | null = null;
+
+  public holdTimer: (() => void) | null = null;
+
+  public keepaliveTimer: (() => void) | null = null;
+
+  // Statistics
+  public messagesReceived: number = 0;
+
+  public messagesSent: number = 0;
+
+  public prefixesReceived: number = 0;
+
+  public uptime: number = 0;
+
+  public establishedTime: number = 0;
+
+  constructor(neighborIP: IPAddress, remoteAS: number, description?: string) {
+    this.neighborIP = neighborIP;
+    this.remoteAS = remoteAS;
+    if (description) this.description = description;
+  }
+
+  public toString(): string {
+    return `${this.neighborIP.toString()} (AS ${this.remoteAS}) - ${BGPState[this.state]}`;
+  }
+}
+
+/**
+ * BGP Route Entry
+ * Stores routing information learned via BGP protocol
+ */
+export class BGPRoute {
+  public network: IPAddress;
+
+  public prefixLength: number;
+
+  public nextHop: IPAddress;
+
+  public asPath: number[] = [];
+
+  public localPref: number = 100;
+
+  public origin: number = 0; // 0=IGP, 1=EGP, 2=Incomplete
+
+  public med: number = 0; // Multi-Exit Discriminator
+
+  public fromNeighbor: IPAddress;
+
+  public lastUpdate: number = 0;
+
+  constructor(
+    network: IPAddress,
+    prefixLength: number,
+    nextHop: IPAddress,
+    fromNeighbor: IPAddress
+  ) {
+    this.network = network;
+    this.prefixLength = prefixLength;
+    this.nextHop = nextHop;
+    this.fromNeighbor = fromNeighbor;
+    this.lastUpdate = Scheduler.getInstance().getDeltaTime();
+  }
+
+  public toString(): string {
+    return `${this.network.toString()}/${this.prefixLength} via ${this.nextHop.toString()}`;
+  }
+
+  public getRouteKey(): string {
+    return `${this.network.toString()}/${this.prefixLength}`;
+  }
+}
+
+/**
+ * BGPService - Border Gateway Protocol Service
+ * Implements RFC 4271 (BGPv4) for inter-domain routing
+ *
+ * BGP is a path-vector routing protocol that exchanges routing information between autonomous systems.
+ * Simplified implementation for educational purposes (Packet Tracer style):
+ * - Basic neighbor establishment (OPEN, KEEPALIVE)
+ * - Route advertisement (UPDATE messages)
+ * - Simple path selection
+ * - Hold timer and Keepalive mechanism
+ */
+export class BGPService
+  extends NetworkServices<RouterHost>
+  implements NetworkListener
+{
+  // Local AS configuration
+  public localAS: number = 65000;
+
+  public routerID: IPAddress = new IPAddress('0.0.0.0');
+
+  // BGP neighbors
+  private neighbors = new Map<string, BGPNeighbor>();
+
+  // BGP routing table (separate from main routing table)
+  private bgpRoutes = new Map<string, BGPRoute>();
+
+  // Configuration
+  public holdTime: number = BGP_DEFAULT_HOLD_TIME;
+
+  public keepaliveTime: number = BGP_DEFAULT_KEEPALIVE_TIME;
+
+  // Timers
+  private maintenanceTimer: (() => void) | null = null;
+
+  constructor(
+    host: RouterHost,
+    localAS: number = 65000,
+    enabled: boolean = false
+  ) {
+    super(host);
+    this.localAS = localAS;
+    this.Enable = enabled;
+
+    // Set router ID to highest interface IP
+    this.updateRouterID();
+  }
+
+  /**
+   * Update router ID based on interfaces
+   * Uses highest IP address on any interface
+   */
+  private updateRouterID(): void {
+    let highestIP = new IPAddress('0.0.0.0');
+
+    this.host.getInterfaces().forEach((ifaceName) => {
+      const iface = this.host.getInterface(ifaceName);
+      const ip = iface.getNetAddress() as IPAddress;
+      if (ip && ip.toNumber() > highestIP.toNumber()) {
+        highestIP = ip;
+      }
+    });
+
+    this.routerID = highestIP;
+  }
+
+  /**
+   * Add a BGP neighbor
+   */
+  public addNeighbor(
+    neighborIP: IPAddress,
+    remoteAS: number,
+    description?: string
+  ): void {
+    const key = neighborIP.toString();
+    if (!this.neighbors.has(key)) {
+      const neighbor = new BGPNeighbor(neighborIP, remoteAS, description);
+      this.neighbors.set(key, neighbor);
+
+      // If service is enabled, try to establish connection
+      if (this.enabled) {
+        this.initiateConnection(neighbor);
+      }
+    }
+  }
+
+  /**
+   * Remove a BGP neighbor
+   */
+  public removeNeighbor(neighborIP: IPAddress): void {
+    const key = neighborIP.toString();
+    const neighbor = this.neighbors.get(key);
+    if (neighbor) {
+      this.resetNeighbor(neighbor);
+      this.neighbors.delete(key);
+
+      // Remove routes learned from this neighbor
+      const routesToRemove: string[] = [];
+      this.bgpRoutes.forEach((route, routeKey) => {
+        if (route.fromNeighbor.equals(neighborIP)) {
+          routesToRemove.push(routeKey);
+          // Remove from main routing table
+          try {
+            const mask = new IPAddress(`255.255.255.255`).getNetworkIP(
+              new IPAddress(`255.255.255.255`, true).fromCIDR(route.prefixLength)
+            ) as IPAddress;
+            this.host.deleteRoute(route.network, mask, route.nextHop);
+          } catch {
+            // Route might not be in main table
+          }
+        }
+      });
+      routesToRemove.forEach((key) => this.bgpRoutes.delete(key));
+    }
+  }
+
+  /**
+   * Get all BGP neighbors
+   */
+  public getNeighbors(): BGPNeighbor[] {
+    return Array.from(this.neighbors.values());
+  }
+
+  /**
+   * Get neighbor by IP
+   */
+  public getNeighbor(neighborIP: IPAddress): BGPNeighbor | undefined {
+    return this.neighbors.get(neighborIP.toString());
+  }
+
+  /**
+   * Get all BGP routes
+   */
+  public getRoutes(): BGPRoute[] {
+    return Array.from(this.bgpRoutes.values());
+  }
+
+  /**
+   * Clear all BGP routes
+   */
+  public clearRoutes(): void {
+    this.bgpRoutes.clear();
+  }
+
+  /**
+   * Enable/disable the BGP service
+   */
+  public override get Enable(): boolean {
+    return this.enabled;
+  }
+
+  public override set Enable(enable: boolean) {
+    super.Enable = enable;
+
+    if (enable) {
+      this.updateRouterID();
+      this.startMaintenanceTimer();
+
+      // Try to establish all configured neighbors
+      this.neighbors.forEach((neighbor) => {
+        this.initiateConnection(neighbor);
+      });
+    } else {
+      this.stopTimers();
+
+      // Reset all neighbors
+      this.neighbors.forEach((neighbor) => {
+        this.resetNeighbor(neighbor);
+      });
+
+      // Clear routing table
+      this.clearRoutes();
+    }
+  }
+
+  /**
+   * Start maintenance timer for keepalive and hold timer checks
+   */
+  private startMaintenanceTimer(): void {
+    if (this.maintenanceTimer) {
+      this.maintenanceTimer();
+    }
+
+    // Check every second for timer expiration
+    const subscription = Scheduler.getInstance()
+      .repeat(1)
+      .subscribe(() => {
+        this.checkTimers();
+      });
+
+    this.maintenanceTimer = () => subscription.unsubscribe();
+  }
+
+  /**
+   * Stop all timers
+   */
+  private stopTimers(): void {
+    if (this.maintenanceTimer) {
+      this.maintenanceTimer();
+      this.maintenanceTimer = null;
+    }
+  }
+
+  /**
+   * Check keepalive and hold timers for all neighbors
+   */
+  private checkTimers(): void {
+    if (!this.enabled) return;
+
+    const currentTime = Scheduler.getInstance().getDeltaTime();
+
+    this.neighbors.forEach((neighbor) => {
+      if (neighbor.state === BGPState.Established) {
+        // Check if we need to send keepalive
+        const timeSinceKeepalive =
+          (currentTime - neighbor.lastKeepalive) /
+          Scheduler.getInstance().getDelay(1);
+        if (timeSinceKeepalive >= neighbor.keepaliveTime) {
+          this.sendKeepalive(neighbor);
+        }
+
+        // Check hold timer
+        const timeSinceUpdate =
+          (currentTime - neighbor.lastUpdate) /
+          Scheduler.getInstance().getDelay(1);
+        if (timeSinceUpdate >= neighbor.holdTime) {
+          // Hold timer expired, close connection
+          this.sendNotification(neighbor, BGPErrorCode.HoldTimerExpired, 0);
+          this.resetNeighbor(neighbor);
+        }
+      }
+    });
+  }
+
+  /**
+   * Initiate BGP connection to neighbor (simplified)
+   */
+  private initiateConnection(neighbor: BGPNeighbor): void {
+    if (neighbor.state !== BGPState.Idle) return;
+
+    neighbor.state = BGPState.Connect;
+    neighbor.lastUpdate = Scheduler.getInstance().getDeltaTime();
+
+    // Simplified: Move directly to OpenSent and send OPEN message
+    // In real BGP, TCP connection establishment happens first
+    Scheduler.getInstance()
+      .delay(0.1)
+      .subscribe(() => {
+        if (neighbor.state === BGPState.Connect) {
+          this.sendOpen(neighbor);
+          neighbor.state = BGPState.OpenSent;
+        }
+      });
+  }
+
+  /**
+   * Reset neighbor to Idle state
+   */
+  private resetNeighbor(neighbor: BGPNeighbor): void {
+    // Stop all timers
+    if (neighbor.connectRetryTimer) {
+      neighbor.connectRetryTimer();
+      neighbor.connectRetryTimer = null;
+    }
+    if (neighbor.holdTimer) {
+      neighbor.holdTimer();
+      neighbor.holdTimer = null;
+    }
+    if (neighbor.keepaliveTimer) {
+      neighbor.keepaliveTimer();
+      neighbor.keepaliveTimer = null;
+    }
+
+    neighbor.state = BGPState.Idle;
+    neighbor.remoteRouterID = null;
+  }
+
+  /**
+   * Send BGP OPEN message
+   */
+  private sendOpen(neighbor: BGPNeighbor): void {
+    // Find interface to reach neighbor
+    const iface = this.findInterfaceForNeighbor(neighbor.neighborIP);
+    if (!iface) return;
+
+    const srcIP = iface.getNetAddress() as IPAddress;
+    const message = new BGPOpenMessage.Builder()
+      .setNetSource(srcIP)
+      .setNetDestination(neighbor.neighborIP)
+      .setMyAutonomousSystem(this.localAS)
+      .setHoldTime(this.holdTime)
+      .setBGPIdentifier(this.routerID)
+      .build()[0];
+
+    iface.sendPacket(message);
+    neighbor.messagesSent += 1;
+    neighbor.lastUpdate = Scheduler.getInstance().getDeltaTime();
+  }
+
+  /**
+   * Send BGP KEEPALIVE message
+   */
+  private sendKeepalive(neighbor: BGPNeighbor): void {
+    const iface = this.findInterfaceForNeighbor(neighbor.neighborIP);
+    if (!iface) return;
+
+    const srcIP = iface.getNetAddress() as IPAddress;
+    const message = new BGPMessage.Builder()
+      .setNetSource(srcIP)
+      .setNetDestination(neighbor.neighborIP)
+      .setBGPType(BGPMessageType.Keepalive)
+      .build()[0];
+
+    iface.sendPacket(message);
+    neighbor.messagesSent += 1;
+    neighbor.lastKeepalive = Scheduler.getInstance().getDeltaTime();
+  }
+
+  /**
+   * Send BGP NOTIFICATION message
+   */
+  private sendNotification(
+    neighbor: BGPNeighbor,
+    errorCode: BGPErrorCode,
+    errorSubcode: number
+  ): void {
+    const iface = this.findInterfaceForNeighbor(neighbor.neighborIP);
+    if (!iface) return;
+
+    const srcIP = iface.getNetAddress() as IPAddress;
+    const message = new BGPNotificationMessage.Builder()
+      .setNetSource(srcIP)
+      .setNetDestination(neighbor.neighborIP)
+      .setErrorCode(errorCode)
+      .setErrorSubcode(errorSubcode)
+      .build()[0];
+
+    iface.sendPacket(message);
+    neighbor.messagesSent += 1;
+  }
+
+  /**
+   * Send BGP UPDATE message with routes
+   */
+  private sendUpdate(neighbor: BGPNeighbor, routes: BGPNLRI[]): void {
+    if (neighbor.state !== BGPState.Established) return;
+
+    const iface = this.findInterfaceForNeighbor(neighbor.neighborIP);
+    if (!iface) return;
+
+    const srcIP = iface.getNetAddress() as IPAddress;
+
+    // Build path attributes (simplified: just AS_PATH and NEXT_HOP)
+    const pathAttrs: BGPPathAttribute[] = [];
+
+    // AS_PATH attribute (simplified representation)
+    pathAttrs.push(new BGPPathAttribute(0x40, 2, [this.localAS]));
+
+    // NEXT_HOP attribute (this router's IP)
+    pathAttrs.push(new BGPPathAttribute(0x40, 3, []));
+
+    const message = new BGPUpdateMessage.Builder()
+      .setNetSource(srcIP)
+      .setNetDestination(neighbor.neighborIP)
+      .setNLRI(routes)
+      .setPathAttributes(pathAttrs)
+      .build()[0];
+
+    iface.sendPacket(message);
+    neighbor.messagesSent += 1;
+  }
+
+  /**
+   * Find interface to reach a neighbor
+   */
+  private findInterfaceForNeighbor(
+    neighborIP: IPAddress
+  ): NetworkInterface | null {
+    // Check all interfaces to find one in the same subnet as neighbor
+    for (const ifaceName of this.host.getInterfaces()) {
+      const iface = this.host.getInterface(ifaceName);
+      const ifaceIP = iface.getNetAddress() as IPAddress;
+      const ifaceMask = iface.getNetMask() as IPAddress;
+
+      if (ifaceIP && ifaceMask) {
+        const ifaceNetwork = ifaceIP.getNetworkIP(ifaceMask);
+        const neighborNetwork = neighborIP.getNetworkIP(ifaceMask);
+
+        if (ifaceNetwork?.equals(neighborNetwork)) {
+          return iface;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Process received BGP messages
+   */
+  public receivePacket(
+    message: NetworkMessage,
+    from: NetworkInterface
+  ): ActionHandle {
+    if (!(message instanceof BGPMessage)) {
+      return ActionHandle.Continue;
+    }
+
+    if (!this.enabled) {
+      return ActionHandle.Continue;
+    }
+
+    const senderIP = message.netSrc as IPAddress;
+    const neighbor = this.getNeighbor(senderIP);
+
+    if (!neighbor) {
+      // Received message from non-configured neighbor, ignore
+      return ActionHandle.Handled;
+    }
+
+    neighbor.messagesReceived += 1;
+    neighbor.lastUpdate = Scheduler.getInstance().getDeltaTime();
+
+    // Process based on message type
+    if (message instanceof BGPOpenMessage) {
+      this.processOpen(message, neighbor);
+    } else if (message instanceof BGPUpdateMessage) {
+      this.processUpdate(message, neighbor);
+    } else if (message.type === BGPMessageType.Keepalive) {
+      this.processKeepalive(neighbor);
+    } else if (message instanceof BGPNotificationMessage) {
+      this.processNotification(message, neighbor);
+    }
+
+    return ActionHandle.Handled;
+  }
+
+  /**
+   * Process BGP OPEN message
+   */
+  private processOpen(message: BGPOpenMessage, neighbor: BGPNeighbor): void {
+    // Verify AS number
+    if (message.myAutonomousSystem !== neighbor.remoteAS) {
+      this.sendNotification(neighbor, BGPErrorCode.OpenMessageError, 2); // Bad Peer AS
+      this.resetNeighbor(neighbor);
+      return;
+    }
+
+    // Store remote router ID
+    neighbor.remoteRouterID = message.bgpIdentifier;
+
+    // Negotiate hold time (use minimum)
+    neighbor.holdTime = Math.min(this.holdTime, message.holdTime);
+    neighbor.keepaliveTime = Math.floor(neighbor.holdTime / 3);
+
+    if (neighbor.state === BGPState.OpenSent) {
+      // Send KEEPALIVE to confirm
+      this.sendKeepalive(neighbor);
+      neighbor.state = BGPState.OpenConfirm;
+    } else if (neighbor.state === BGPState.OpenConfirm) {
+      // Should not happen in normal flow, but handle it
+      this.sendKeepalive(neighbor);
+    }
+  }
+
+  /**
+   * Process BGP KEEPALIVE message
+   */
+  private processKeepalive(neighbor: BGPNeighbor): void {
+    if (neighbor.state === BGPState.OpenConfirm) {
+      // Move to Established
+      neighbor.state = BGPState.Established;
+      neighbor.establishedTime = Scheduler.getInstance().getDeltaTime();
+      neighbor.lastKeepalive = neighbor.establishedTime;
+
+      // Advertise our local routes
+      this.advertiseRoutes(neighbor);
+    } else if (neighbor.state === BGPState.Established) {
+      // Just update last update time (already done in receivePacket)
+    }
+  }
+
+  /**
+   * Process BGP UPDATE message
+   */
+  private processUpdate(message: BGPUpdateMessage, neighbor: BGPNeighbor): void {
+    if (neighbor.state !== BGPState.Established) {
+      return;
+    }
+
+    // Process withdrawn routes
+    message.withdrawnRoutes.forEach((nlri) => {
+      const key = `${nlri.prefix.toString()}/${nlri.prefixLength}`;
+      const route = this.bgpRoutes.get(key);
+      if (route && route.fromNeighbor.equals(neighbor.neighborIP)) {
+        this.bgpRoutes.delete(key);
+        neighbor.prefixesReceived -= 1;
+
+        // Remove from main routing table
+        try {
+          const mask = new IPAddress(`255.255.255.255`).getNetworkIP(
+            new IPAddress(`255.255.255.255`, true).fromCIDR(nlri.prefixLength)
+          ) as IPAddress;
+          this.host.deleteRoute(route.network, mask, route.nextHop);
+        } catch {
+          // Route might not be in main table
+        }
+      }
+    });
+
+    // Process advertised routes
+    message.nlri.forEach((nlri) => {
+      const key = `${nlri.prefix.toString()}/${nlri.prefixLength}`;
+
+      // Create BGP route
+      const route = new BGPRoute(
+        nlri.prefix,
+        nlri.prefixLength,
+        neighbor.neighborIP, // Use neighbor as next hop
+        neighbor.neighborIP
+      );
+
+      // Simple path selection: just accept the route
+      this.bgpRoutes.set(key, route);
+      neighbor.prefixesReceived += 1;
+
+      // Add to main routing table
+      try {
+        const mask = new IPAddress(`255.255.255.255`).getNetworkIP(
+          new IPAddress(`255.255.255.255`, true).fromCIDR(nlri.prefixLength)
+        ) as IPAddress;
+        this.host.addRoute(route.network, mask, route.nextHop);
+      } catch {
+        // Route might already exist
+      }
+    });
+  }
+
+  /**
+   * Process BGP NOTIFICATION message
+   */
+  private processNotification(
+    _message: BGPNotificationMessage,
+    neighbor: BGPNeighbor
+  ): void {
+    // Peer is closing connection, reset neighbor
+    this.resetNeighbor(neighbor);
+  }
+
+  /**
+   * Advertise local routes to established neighbor
+   */
+  private advertiseRoutes(neighbor: BGPNeighbor): void {
+    const routes: BGPNLRI[] = [];
+
+    // Advertise directly connected networks
+    this.host.getInterfaces().forEach((ifaceName) => {
+      const iface = this.host.getInterface(ifaceName);
+      const ip = iface.getNetAddress() as IPAddress;
+      const mask = iface.getNetMask() as IPAddress;
+
+      if (ip && mask) {
+        const network = ip.getNetworkIP(mask) as IPAddress;
+        routes.push(new BGPNLRI(network, mask.CIDR));
+      }
+    });
+
+    if (routes.length > 0) {
+      this.sendUpdate(neighbor, routes);
+    }
+  }
+
+  /**
+   * Cleanup resources
+   */
+  public destroy(): void {
+    this.stopTimers();
+
+    // Reset all neighbors
+    this.neighbors.forEach((neighbor) => {
+      this.sendNotification(neighbor, BGPErrorCode.Cease, 0);
+      this.resetNeighbor(neighbor);
+    });
+
+    this.clearRoutes();
+  }
+}


### PR DESCRIPTION
- Add BGP protocol message classes (OPEN, UPDATE, KEEPALIVE, NOTIFICATION)
- Implement BGP service with neighbor management and state machine
- Add BGP finite state machine (Idle, Connect, OpenSent, OpenConfirm, Established)
- Create BGP route table and path selection
- Add useBgpService React hook for state management
- Create BgpServiceConfig UI component for BGP configuration
- Integrate BGP tab in ServiceTab for router configuration
- Add comprehensive test suite (22 tests) for BGP protocol
- Register BGP service in RouterHost

This implementation provides basic BGP functionality similar to Cisco Packet Tracer:
- AS number configuration
- BGP neighbor relationships
- Route advertisement and learning
- Keepalive and hold timer mechanisms
- Basic path vector routing